### PR TITLE
docs: fix documentation regarding terraform and vet

### DIFF
--- a/apps/github/overview.mdx
+++ b/apps/github/overview.mdx
@@ -84,4 +84,4 @@ The **GitHub Check** will fail if there is any _Verified Malicious Package_, any
   - `composer.lock`
   7. **Maven (Java)**
   - `pom.xml`
-  - `grade.lockfile`
+  - `gradle.lockfile`

--- a/apps/jfrog/overview.mdx
+++ b/apps/jfrog/overview.mdx
@@ -31,7 +31,7 @@ those packages for every developer on that instance.
     safedep auth login --tenant your-tenant.safedep.io --api-key YOUR_API_KEY
 
     # via Environment variables
-    export SAFEDEP_TENANT=your-tenant.safedep.io
+    export SAFEDEP_TENANT_ID=your-tenant.safedep.io
     export SAFEDEP_API_KEY=YOUR_API_KEY
     safedep auth login
     ```

--- a/cloud/authentication.mdx
+++ b/cloud/authentication.mdx
@@ -98,8 +98,8 @@ For custom applications, implement OAuth2 Device Code flow. Reference implementa
 
 ```bash
 # Set credentials
-export SAFEDEP_API_KEY=sk_your_api_key
-export SAFEDEP_TENANT_ID=your-company
+export SAFEDEP_API_KEY=your_api_key
+export SAFEDEP_TENANT_ID=your-company.safedep.io
 
 # Use with vet
 vet scan -D . --report-sync \
@@ -135,35 +135,26 @@ vet cloud whoami
 
 ## Authentication Headers
 
-### API Key Authentication
+The SafeDep API is a [gRPC API with a ConnectRPC facade](/api-reference/introduction), not a REST API — there are no REST paths to call. Whatever transport you use (gRPC over HTTP/2 or JSON over HTTP/1.1), requests carry the same two headers:
 
-```bash
-curl -H "Authorization: Bearer sk_your_api_key" \
-     -H "X-Tenant-ID: your-tenant" \
-     https://api.safedep.io/v2/insights/packages
-```
+| Header | Value |
+|--------|-------|
+| `Authorization` | Your API key or JWT, sent **as-is** (no `Bearer` prefix) |
+| `X-Tenant-ID` | Your tenant domain (e.g. `your-company.safedep.io`) |
 
-### JWT Authentication
+- **Data plane** (`api.safedep.io`) accepts an API key or a JWT.
+- **Control plane** (`cloud.safedep.io`) accepts a JWT.
 
-```bash
-curl -H "Authorization: Bearer your_jwt_token" \
-     -H "X-Tenant-ID: your-tenant" \
-     https://cloud.safedep.io/api/v1/projects
-```
+For the available services and methods, see the canonical API specification at [buf.build/safedep/api](https://buf.build/safedep/api), which also publishes generated SDKs.
 
 ## Rate Limiting
 
-### Data Plane Limits
+SafeDep Cloud enforces fair-usage rate limits at the API gateway, measured **per second** — there is no hourly quota:
 
-- **API Key Authentication**: Fair usage policy applies
-- **Rate limits**: 1000 requests per hour per API key
-- **Burst capacity**: 50 requests per minute
+- **Data plane** (`api.safedep.io`): up to **500 requests/second** per API key
+- **Management API**: up to **20 requests/second**
 
-### Control Plane Limits
-
-- **JWT Authentication**: Higher limits for authenticated users
-- **Rate limits**: 5000 requests per hour per user
-- **Burst capacity**: 100 requests per minute
+These limits are applied under a fair usage policy and are subject to change.
 
 ## Security Best Practices
 
@@ -238,11 +229,8 @@ vet cloud login --tenant your-tenant
 ## API Reference
 
 <CardGroup cols={2}>
-  <Card title="Control Plane API" icon="cog" href="https://cloud.safedep.io/api/docs">
-    Management and configuration API documentation
-  </Card>
-  <Card title="Data Plane API" icon="database" href="https://api.safedep.io/docs">
-    Insights and scanning data API documentation
+  <Card title="API Specification" icon="book" href="https://buf.build/safedep/api">
+    Canonical gRPC/ConnectRPC schemas, docs, and generated SDKs
   </Card>
   <Card title="OAuth2 Implementation" icon="code" href="https://github.com/safedep/vet/blob/main/cmd/cloud/login.go">
     Reference implementation for OAuth2 Device Code flow

--- a/cloud/endpoint-hub/package-guard.mdx
+++ b/cloud/endpoint-hub/package-guard.mdx
@@ -18,7 +18,7 @@ Package Guard shows package installs and usage across your endpoints. It runs on
 ## Prerequisites
 
 - Install PMG using the [quickstart guide](/pmg/quickstart)
-- Have a SafeDep Cloud tenant ID and tenant domain (see [Cloud quickstart](/cloud/quickstart))
+- Have a SafeDep Cloud tenant ID and API key (see [Cloud quickstart](/cloud/quickstart))
 
 ## Enable cloud sync
 
@@ -51,7 +51,7 @@ Package Guard shows package installs and usage across your endpoints. It runs on
     ```bash
     pmg cloud login
     ```
-    Enter your **tenant ID** and **tenant domain** when prompted.
+    Enter your **tenant ID** and **API key** when prompted.
   </Step>
 
   <Step title="Sync to SafeDep Cloud">

--- a/cloud/malware-analysis.mdx
+++ b/cloud/malware-analysis.mdx
@@ -95,7 +95,7 @@ vet scan -M Gemfile.lock --malware
 Scan specific packages using Package URLs:
 
 ```bash
-vet scan --purl pkg:/npm/llm-oracle@1.0.2 --malware
+vet scan --purl pkg:npm/llm-oracle@1.0.2 --malware
 ```
 
 <img src="/images/vet-malysis-llm-oracle.png" alt="Malware analysis results for llm-oracle package" />
@@ -134,7 +134,6 @@ jobs:
         uses: safedep/vet-action@v1
         with:
           cloud: true
-          malware: true
           cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
           cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT }}
         env:
@@ -166,7 +165,7 @@ export VET_ENABLE_PACKAGE_INSPECT_COMMAND=true
 Perform detailed analysis of individual packages:
 
 ```bash
-vet inspect malware --purl pkg:/npm/llm-oracle@1.0.2
+vet inspect malware --purl pkg:npm/llm-oracle@1.0.2
 ```
 
 <Note>
@@ -185,7 +184,7 @@ Export analysis results as JSON:
 
 ```bash
 vet inspect malware \
-  --purl pkg:/npm/llm-oracle@1.0.2 \
+  --purl pkg:npm/llm-oracle@1.0.2 \
   --report-json /tmp/analysis.json
 ```
 

--- a/cloud/sync.mdx
+++ b/cloud/sync.mdx
@@ -179,9 +179,8 @@ jobs:
           cloud: true
           cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
           cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
-          policy: '.github/security-policy.yml'
-          fail-on-violation: true
-          malware: true
+          policy: '.github/vet/policy.yml'
+          paranoid: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/faq.mdx
+++ b/faq.mdx
@@ -301,10 +301,10 @@ Common filter issues and solutions:
   </Accordion>
   
   <Accordion title="Use Warning Mode">
-    Don't fail builds while tuning policies:
+    The action does not fail the build by default, so you can surface findings without blocking while you tune policies. Just leave `paranoid` off (its default is `false`):
     ```yaml
     with:
-      fail-on-violation: false
+      paranoid: false
     ```
   </Accordion>
 </AccordionGroup>
@@ -317,11 +317,12 @@ vet collects:
 - **Package metadata** from public registries
 - **Vulnerability data** from public databases (OSV, NVD)
 - **OpenSSF Scorecard** metrics from public repositories
-- **No source code** is ever analyzed or transmitted
+
+Only **package coordinates** (ecosystem, name, version) leave your machine. Your source code is never transmitted.
 
 ### Does vet send my code anywhere?
 
-No. vet only analyzes package manifest files (like package-lock.json) and does not access or transmit your source code. All analysis is based on publicly available package metadata.
+No. vet reads your manifests, lockfiles, and — when code analysis is enabled — your source code **locally** to identify and trace dependencies. Only package coordinates are sent to SafeDep for vulnerability and malware analysis; your source code never leaves your machine.
 
 ### Can I use vet in air-gapped environments?
 

--- a/pmg/updates.mdx
+++ b/pmg/updates.mdx
@@ -72,7 +72,7 @@ description: "New updates related to Package Manager Guard (PMG)"
     
     ## Configuration
     
-    Trusted packages are configured in the `config.yml` file. See [config template](../config/config.template.yml) for the configuration schema.
+    Trusted packages are configured in the `config.yml` file. See [config template](https://github.com/safedep/pmg/blob/main/config/config.template.yml) for the configuration schema.
     If you don't have a `config.yml` file, you can create one by running `pmg setup install`.
     
     ### Example

--- a/vet/advanced/build-your-own-queries.mdx
+++ b/vet/advanced/build-your-own-queries.mdx
@@ -91,6 +91,6 @@ vet query --from /tmp/dump \
 ```bash
 # Find high-risk packages (multiple criteria)
 vet query --from /tmp/dump \
-    --filter 'vulns.high.size() > 0 && scorecard.scores.Security < 5 && projects.exists(p, p.stars < 100)'
+    --filter 'vulns.high.size() > 0 && scorecard.scores["Security-Policy"] < 5 && projects.exists(p, p.stars < 100)'
 ```
 

--- a/vet/advanced/filtering.mdx
+++ b/vet/advanced/filtering.mdx
@@ -104,7 +104,7 @@ Refer to the [filter input specification](https://github.com/safedep/vet/blob/ma
     scorecard.scores.Maintained == 0
     
     # Overall OpenSSF Scorecard score
-    scorecard.Score < 5
+    scorecard.score < 5
     ```
   </Tab>
   
@@ -152,7 +152,7 @@ projects.exists(x, x.stars < 50)
 # Compliance violations
 !licenses.exists(p, p in ["MIT", "Apache-2.0", "BSD-3-Clause"]) ||
 vulns.high.size() > 0 ||
-scorecard.Score < 3
+scorecard.score < 3
 
 # Production-ready packages
 vulns.critical.size() == 0 &&
@@ -253,7 +253,7 @@ vet scan -D . \
 
 # Identify potential supply chain risks
 vet scan -D . \
-    --filter 'scorecard.scores.Supply_Chain < 5 || scorecard.scores.Token_Permissions < 5' \
+    --filter 'scorecard.scores["Pinned-Dependencies"] < 5 || scorecard.scores["Token-Permissions"] < 5' \
     --report-json supply-chain-risks.json
 ```
 

--- a/vet/advanced/policy-as-code.mdx
+++ b/vet/advanced/policy-as-code.mdx
@@ -73,11 +73,11 @@ filters:
     
   - name: minimum-maintenance
     value: |
-      scorecard.scores.Maintained < 5
-    
-  - name: security-score
+      scorecard.scores["Maintained"] < 5
+
+  - name: low-overall-scorecard
     value: |
-      scorecard.Score < 3
+      scorecard.score < 3
   
 ```
 
@@ -112,8 +112,8 @@ Use filter suites in your CI pipeline:
 - name: Security Policy Check
   uses: safedep/vet-action@v1
   with:
-    policy: '.github/vet-policy.yml'
-    fail-on-violation: true
+    policy: '.github/vet/policy.yml'
+    paranoid: true
 ```
 
 ## Advanced Policy Examples
@@ -139,19 +139,17 @@ filters:
 name: Supply Chain Security
 description: Advanced supply chain security checks
 filters:
-  - name: unsigned-packages
+  - name: known-malware
     value: |
-      !package.signed
-    
-  - name: suspicious-maintainers
+      vulns.all.exists(v, v.id.startsWith("MAL-"))
+
+  - name: dangerous-release-workflow
     value: |
-      package.maintainers.size() == 1 && 
-      package.published_at > timestamp("2023-01-01T00:00:00Z")
-    
-  - name: typosquatting-risk
+      scorecard.scores["Dangerous-Workflow"] == 0
+
+  - name: low-popularity
     value: |
-      package.name.size() < 3 || 
-      package.name.contains("_") && package.downloads < 1000
+      projects.exists(p, (p.type == "GITHUB") && (p.stars < 10))
 ```
 
 ### Development vs Production Policies
@@ -183,11 +181,11 @@ filters:
       
       - name: maintenance-requirements
         value: |
-          scorecard.scores.Maintained < 7
+          scorecard.scores["Maintained"] < 7
       
       - name: security-requirements
         value: |
-          scorecard.scores.Security < 5
+          scorecard.scores["Security-Policy"] < 5
     ```
   </Tab>
 </Tabs>
@@ -229,10 +227,11 @@ The Common Expression Language (CEL) provides the foundation for writing policie
 
 ### Available Data Fields
 
-- `vulns.critical`, `vulns.high`, `vulns.medium`, `vulns.low` - Vulnerability arrays
-- `licenses` - Array of license identifiers
-- `scorecard.scores.*` - OpenSSF Scorecard metrics
-- `package.*` - Package metadata (name, version, published_at, etc.)
+- `pkg` - Package metadata: `pkg.ecosystem`, `pkg.name`, `pkg.version`
+- `vulns.all`, `vulns.critical`, `vulns.high`, `vulns.medium`, `vulns.low` - Vulnerability arrays; each item has an `id` (e.g. `vulns.all.exists(v, v.id.startsWith("MAL-"))`)
+- `licenses` - Array of SPDX license identifiers
+- `scorecard.score` - Aggregate OpenSSF Scorecard score; `scorecard.scores["Check-Name"]` - per-check score (e.g. `"Maintained"`, `"Dangerous-Workflow"`, `"Token-Permissions"`)
+- `projects` - Source project info (e.g. `projects.exists(p, p.type == "GITHUB" && p.stars < 10)`)
 
 ### Common Operations
 

--- a/vet/guides/terraform-supply-chain-audit.mdx
+++ b/vet/guides/terraform-supply-chain-audit.mdx
@@ -203,8 +203,8 @@ jobs:
             --report-sync-project ${{ github.repository }} \
             --report-sync-project-version ${{ github.ref_name }}
         env:
-          SAFEDEP_CLOUD_API_KEY: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
-          SAFEDEP_CLOUD_TENANT: ${{ secrets.SAFEDEP_CLOUD_TENANT }}
+          SAFEDEP_API_KEY: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
+          SAFEDEP_TENANT_ID: ${{ secrets.SAFEDEP_CLOUD_TENANT }}
           
       - name: Check for Unofficial Providers
         run: |
@@ -251,42 +251,15 @@ terraform-audit:
   dependencies:
     - terraform-init
   variables:
-    SAFEDEP_CLOUD_API_KEY: $SAFEDEP_CLOUD_API_KEY
-    SAFEDEP_CLOUD_TENANT: $SAFEDEP_CLOUD_TENANT
+    SAFEDEP_API_KEY: $SAFEDEP_CLOUD_API_KEY
+    SAFEDEP_TENANT_ID: $SAFEDEP_CLOUD_TENANT
 ```
 
 ## Policy Enforcement
 
-### Custom Provider Policies
+Terraform provider tier (official, partner, community) lives in SafeDep Cloud's query layer — not in vet's local `--filter-suite` engine, which evaluates package-level signals (vulnerabilities, licenses, OpenSSF Scorecard) and has no notion of provider tiers. To enforce provider policies, query the synced inventory and fail the build on disallowed providers.
 
-Create policies to enforce provider compliance:
-
-```yaml
-# terraform-provider-policy.yml
-name: Terraform Provider Security Policy
-description: Enforce approved provider usage
-filters:
-  - name: unofficial-providers-blocked
-    value: |
-      terraform_providers.tier != "official" && 
-      !packages.name.startsWith("registry.terraform.io/hashicorp/")
-      
-  - name: community-providers-require-approval
-    value: |
-      terraform_providers.tier == "community" && 
-      !packages.name.contains("approved-community-providers")
-```
-
-Use the policy during scanning:
-
-```bash
-vet scan -D . \
-  --filter-suite terraform-provider-policy.yml \
-  --filter-fail \
-  --report-sync \
-  --report-sync-project myproject \
-  --report-sync-project-version main
-```
+The **Check for Unofficial Providers** step in the GitHub Actions example above demonstrates this pattern: it queries `terraform_providers.tier` and exits non-zero when any non-official provider is present. Adapt that query to encode your approved-provider rules.
 
 ## Schema Exploration
 


### PR DESCRIPTION
Re-verified each audit finding against product source (vet, pmg,
control-tower, safedep-api, apiguard, safedep-cli, devops) before fixing.
Five audit claims were themselves wrong and were dropped (API reference
already correct; pmg version/ecosystem table fine; pmg config path was a
mis-read; the package-guard fix differs from what the audit proposed).

- cloud/authentication: API uses raw `authorization` header (no `Bearer`)
  and keys have no `sk_` format; replace fictional REST curl paths with the
  auth header contract + a link to buf.build/safedep/api; correct rate limits
  to data plane 500 req/s, Management API 20 req/s, no hourly quota (apiguard
  Tyk policies); repoint the API reference card at buf.build.
- vet policy/filter CEL: `scorecard.Score`->`scorecard.score`; replace
  fabricated fields (`package.*`, invented `Security`/`Supply_Chain` checks)
  with real expressions from vet's sample filter-suites and the FilterInput
  proto (`pkg`, `vulns`, `scorecard.scores["..."]`, `projects`, `licenses`);
  bracket form for hyphenated check names (e.g. "Token-Permissions").
- vet-action: drop non-existent inputs `fail-on-violation` and `malware`;
  use `paranoid: true`; standardize policy path to `.github/vet/policy.yml`.
- env vars: stop passing `SAFEDEP_CLOUD_*` (GitHub-secret names) straight to
  the vet binary; use `SAFEDEP_API_KEY`/`SAFEDEP_TENANT_ID` (terraform, jfrog).
- malware-analysis: malformed PURLs `pkg:/npm/`->`pkg:npm/`.
- github app: lockfile typo `grade.lockfile`->`gradle.lockfile`.
- package-guard: the second login prompt is the API key, not a tenant domain.
- faq: source is analyzed locally and never transmitted (vet has local code
  analysis); only package coordinates leave the machine.
- pmg/updates: fix broken relative link to config.template.yml.

