### PR TITLE
docs: restructure Cloud docs around the safedep CLI and sources

### DIFF
--- a/governance/cloud/authentication.mdx
+++ b/governance/cloud/authentication.mdx
@@ -1,231 +1,105 @@
 ---
 title: Authentication
-description: "Understand SafeDep Cloud authentication methods and API access patterns"
+description: "How SafeDep Cloud authentication works and how to authenticate the safedep CLI, vet, and CI/CD pipelines"
 ---
 
-The SafeDep Cloud API has two planes, each with different authentication requirements and access patterns.
+Every tool that talks to SafeDep Cloud authenticates with two values: a **tenant domain** (for example `your-company.safedep.io`) and a credential. The credential type depends on which API plane the tool calls:
 
-## API Architecture
+- **Data plane** (`api.safedep.io`): package insights, scanning, and sync. Authenticates with an **API key**.
+- **Control plane** (`cloud.safedep.io`): tenant, policy, and management operations, including SQL queries. Authenticates with a **JWT** from an OAuth2 login.
 
-<CardGroup cols={2}>
-  <Card title="Control Plane" icon="cog">
-    Configuration, reporting, and management operations
-  </Card>
-  <Card title="Data Plane" icon="database">
-    Package insights, scanning data, and tool integrations
-  </Card>
-</CardGroup>
+Generate API keys at [app.safedep.io/settings/api-keys](https://app.safedep.io/settings/api-keys). For request headers, OAuth2/OIDC endpoints, and rate limits, see the [API reference](/reference/api-introduction). For the full hostname list, see the [endpoints reference](/reference/endpoints).
 
-<Info>
-All APIs for security tools integration are part of the Data Plane. These APIs require an API key for authentication and may enforce rate limits under a fair usage policy.
-</Info>
+## safedep CLI
 
-## API Endpoints and Authentication
-
-Each plane has its own endpoint and authentication method:
-
-- **Data plane** (`api.safedep.io`): package insights, scanning, and malware analysis. Authenticated with an **API key**.
-- **Control plane** (`cloud.safedep.io`): tenant, policy, and management operations. Authenticated with a **JWT**.
-
-For the full list of SafeDep hostnames, including the console, identity provider, community API, and hosted MCP server, see the [Endpoints reference](/reference/endpoints).
-
-## Data Plane Authentication
-
-### API Key Authentication
-
-The standard method for tool integrations and automated access:
-
-<Steps>
-  <Step title="Generate API Key">
-    Create an API key in your SafeDep Cloud tenant settings
-  </Step>
-  
-  <Step title="Configure Environment">
-    Set the API key in your environment:
-    ```bash
-    export SAFEDEP_API_KEY=your-api-key-here
-    export SAFEDEP_TENANT_ID=your-tenant-domain  # e.g. your-team.your-org.safedep.io
-    ```
-  </Step>
-  
-  <Step title="Use with Vet">
-    Configure Vet to use the API key:
-    ```bash
-    vet auth configure --tenant your-tenant-domain
-    ```
-  </Step>
-</Steps>
-
-## Control Plane Authentication
-
-### OAuth2/OIDC Integration
-
-The SafeDep Cloud Identity Service at `https://auth.safedep.io` provides OAuth2/OIDC authentication.
-
-**OpenID Configuration Endpoint:**
-```
-https://auth.safedep.io/.well-known/openid-configuration
-```
-
-### Device Code Flow
-
-For command-line tools, use the OAuth2 Device Code flow:
+`safedep auth login` runs an OAuth2 device flow in your browser, selects a tenant, creates an API key, and stores the credentials in your OS keychain:
 
 ```bash
-# Initiate device code flow
-vet cloud login --tenant your-tenant-domain
-```
-
-This opens a browser for authentication and stores the JWT token locally.
-
-### Programmatic Integration
-
-For custom applications, implement the OAuth2 Device Code flow. A reference implementation is available in the [Vet OAuth2 client](https://github.com/safedep/vet/blob/main/cmd/cloud/login.go).
-
-## Authentication Examples
-
-### Basic API Key Usage
-
-```bash
-# Set credentials
-export SAFEDEP_API_KEY=your_api_key
-export SAFEDEP_TENANT_ID=your-company.safedep.io
-
-# Use with vet
-vet scan -D . --report-sync \
-  --report-sync-project myproject \
-  --report-sync-project-version main
-```
-
-### JWT-Based Access
-
-```bash
-# Login with the OAuth device code flow
-safedep auth login --tenant your-company.safedep.io
-
-# Query aggregated data
-safedep query exec --sql "SELECT projects.name FROM projects WHERE projects.origin_source = 'SOURCE_GITHUB'"
-
-# Check authentication status
+safedep auth login
 safedep auth status
 ```
 
-### GitHub Actions Integration
+For non-interactive environments, log in with a static API key instead of the device flow:
 
-```yaml
-- name: SafeDep Cloud Integration
-  uses: safedep/vet-action@v1
-  with:
-    cloud: true
-    cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
-    cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```bash
+safedep auth login --api-key --tenant your-company.safedep.io
 ```
 
-## Authentication Headers
+The key is read from `--api-key-value`, stdin (with `--from-stdin`), the `SAFEDEP_API_KEY` environment variable, or an interactive prompt, in that order. Work with multiple tenants using `--profile` and `safedep auth profile list`. See the [CLI command reference](https://github.com/safedep/cli/tree/main/docs/cmd) for all flags.
 
-The SafeDep API is a [gRPC API with a ConnectRPC facade](/reference/api-introduction), not a REST API. Regardless of transport (gRPC over HTTP/2 or JSON over HTTP/1.1), requests carry the same two headers:
+## vet
 
-| Header | Value |
-|--------|-------|
-| `Authorization` | Your API key or JWT, sent **as-is** (no `Bearer` prefix) |
-| `X-Tenant-ID` | Your tenant domain (e.g. `your-company.safedep.io`) |
+vet uses an API key for scanning and [sync](/governance/cloud/sync):
 
-- **Data plane** (`api.safedep.io`) accepts an API key or a JWT.
-- **Control plane** (`cloud.safedep.io`) accepts a JWT.
+```bash
+vet auth configure --tenant your-company.safedep.io
+```
 
-For the available services and methods, see the canonical API specification at [buf.build/safedep/api](https://buf.build/safedep/api), which also publishes generated SDKs.
+You will be prompted to enter the API key. Verify the connection:
 
-## Rate Limiting
+```bash
+vet auth verify
+```
 
-SafeDep Cloud enforces rate limits at the API gateway, measured **per second**, with no hourly quota:
+Control plane commands under `vet cloud` use the OAuth2 device flow instead:
 
-- **Data plane** (`api.safedep.io`): up to **500 requests/second** per API key
-- **Management API**: up to **20 requests/second**
+```bash
+vet cloud login --tenant your-company.safedep.io
+vet cloud whoami
+```
 
-These limits are subject to change.
+To log out, delete the stored credentials: `rm ~/.safedep/vet-auth.yml`.
 
-## Security Best Practices
+## CI/CD pipelines
 
-<AccordionGroup>
-  <Accordion title="API Key Management">
-    - Store API keys securely using environment variables or secret management systems
-    - Rotate API keys regularly (recommended: every 90 days)
-    - Use different API keys for different environments (dev, staging, prod)
-    - Never commit API keys to version control
-  </Accordion>
-  
-  <Accordion title="JWT Token Handling">
-    - JWT tokens have limited lifetime (typically 24 hours)
-    - Implement automatic token refresh in long-running applications
-    - Store tokens securely in the OS keychain when possible
-    - Clear tokens on logout or application termination
-  </Accordion>
-  
-  <Accordion title="Network Security">
-    - Always use HTTPS for API communications
-    - Implement proper certificate validation
-    - Consider IP allowlisting for production environments
-    - Monitor authentication logs for suspicious activity
-  </Accordion>
-</AccordionGroup>
+Tools read credentials from environment variables, so pipelines need no interactive login:
 
-## Troubleshooting Authentication Issues
+```bash
+export SAFEDEP_API_KEY=your-api-key
+export SAFEDEP_TENANT_ID=your-company.safedep.io
+```
 
-### Common Error Messages
+Store both as CI secrets. Across SafeDep docs, the secret names are `SAFEDEP_CLOUD_API_KEY` and `SAFEDEP_CLOUD_TENANT_DOMAIN`. [vet-action](https://github.com/safedep/vet-action) reads them through its `cloud-key` and `cloud-tenant` inputs instead of environment variables.
 
-#### "User Not Found"
+For working pipeline configurations (GitHub Actions, GitLab, Jenkins, Azure DevOps), see [Cloud Sync](/governance/cloud/sync#sync-from-github-actions).
+
+## Troubleshooting
+
+### Identity not registered
+
 ```
 ERRO[0001] Failed to execute whoami: rpc error: code = Unauthenticated desc = unauthenticated: Token auth failed: No user: record not found
 ```
 
-**Solution**: The user is not registered. Follow the [quickstart guide](/governance/cloud/quickstart) to register with SafeDep Cloud.
+Your identity is not registered with SafeDep Cloud. Sign up first: see the [quickstart](/governance/cloud/quickstart).
 
-#### "Tenant Not Found"
+### Tenant not found
+
 ```
 ERRO[0001] Failed to execute query: rpc error: code = Unknown desc = failed to resolve tenant: record not found
 ```
 
-**Solution**: Configure the tenant using:
-```bash
-vet auth configure --tenant <tenant-domain>
-# or
-vet cloud login --tenant <tenant-domain>
-```
+No tenant is configured. Set it with `vet auth configure --tenant <tenant-domain>` or `vet cloud login --tenant <tenant-domain>`. If you've forgotten your tenant domain, run `vet cloud login` followed by `vet cloud whoami` to list the tenants you can access.
 
-If you've forgotten your tenant domain:
-```bash
-vet cloud login
-vet cloud whoami  # Shows your identity and accessible tenants
-```
-
-### Authentication Debugging
+### Checking credentials
 
 ```bash
-# Check current authentication status
-vet cloud whoami
-
-# Verify API key configuration
-vet auth verify
-
-# Clear stored authentication
-rm ~/.safedep/vet-auth.yml
-
-# Re-authenticate
-vet cloud login --tenant your-tenant
+safedep auth status   # safedep CLI session
+vet auth verify       # vet API key
+vet cloud whoami      # vet OAuth identity and tenants
 ```
-
-## API Reference
 
 <CardGroup cols={2}>
-  <Card title="API Specification" icon="book" href="https://buf.build/safedep/api">
-    Canonical gRPC/ConnectRPC schemas, docs, and generated SDKs
+  <Card title="API Reference" icon="book" href="/reference/api-introduction">
+    Transport, request headers, OAuth2/OIDC, and rate limits
   </Card>
-  <Card title="OAuth2 Implementation" icon="code" href="https://github.com/safedep/vet/blob/main/cmd/cloud/login.go">
-    Reference implementation for OAuth2 Device Code flow
+  <Card title="Cloud Quickstart" icon="rocket" href="/governance/cloud/quickstart">
+    Create a tenant and log in with the safedep CLI
   </Card>
-  <Card title="Quick Start Guide" icon="rocket" href="/governance/cloud/quickstart">
-    Get started with SafeDep Cloud authentication
+  <Card title="Cloud Sync" icon="arrows-rotate" href="/governance/cloud/sync">
+    Send data to your tenant from vet, PMG, and endpoint scans
+  </Card>
+  <Card title="API Specification" icon="code" href="https://buf.build/safedep/api">
+    Canonical gRPC/ConnectRPC schemas and generated SDKs
   </Card>
 </CardGroup>

--- a/governance/cloud/faq.mdx
+++ b/governance/cloud/faq.mdx
@@ -72,7 +72,7 @@ ERRO[0001] Request failed: rpc error: code = ResourceExhausted desc = rate limit
 ```
 
 **Solution:**
-- Back off briefly and retry. SafeDep enforces per-second rate limits, so a short pause clears the error (see [Authentication](/governance/cloud/authentication#rate-limiting) for the current limits)
+- Back off briefly and retry. SafeDep enforces per-second rate limits, so a short pause clears the error (see the [API reference](/reference/api-introduction#rate-limiting) for the current limits)
 - Reduce the frequency of API calls and use batch operations where possible
 - Contact support for increased rate limits if needed
 

--- a/governance/cloud/quickstart.mdx
+++ b/governance/cloud/quickstart.mdx
@@ -1,156 +1,91 @@
 ---
 title: "SafeDep Cloud Quickstart"
-description: "Get started with SafeDep Cloud in under 10 minutes"
+description: "Create a SafeDep Cloud tenant, authenticate the safedep CLI, connect a data source, and run your first query"
 ---
 
-<Note>[GitHub App Integration](https://github.com/apps/safedep) is available for free. See [other integrations](/governance/integrations/overview) for more details</Note>
+SafeDep Cloud aggregates findings from SafeDep tools into a tenant you can query and govern from one place. The [`safedep` CLI](https://github.com/safedep/cli) is the command line client for your tenant: it handles login, endpoint fleet visibility, and SQL queries over synced data. This guide takes you from a new account to your first query.
 
-SafeDep Cloud is a control and data aggregation service that works with security tools like [Vet](https://github.com/safedep/vet).
-This guide walks you through connecting Vet to SafeDep Cloud for centralized policy management and reporting.
-
-## What You'll Accomplish
-
-<CardGroup cols={2}>
-  <Card title="Query by Risks" icon="search">
-    Find critical vulnerabilities across all your projects
-  </Card>
-  <Card title="Policy Violations" icon="exclamation-triangle">
-    Monitor and track policy violations from all Vet instances
-  </Card>
-  <Card title="Policy Management" icon="cogs">
-    Test and deploy policies across all Vet deployments
-  </Card>
-  <Card title="Malware Analysis" icon="virus">
-    Threat detection backed by cloud malware analysis
-  </Card>
-</CardGroup>
-
-## Web Onboarding
+## Create your tenant
 
 <Steps>
-  <Step title="Create Account">
-    Navigate to [app.safedep.io](https://app.safedep.io/) and sign up
+  <Step title="Create an account">
+    Sign up at [app.safedep.io](https://app.safedep.io/).
   </Step>
 
-  <Step title="Create Tenant">
-    Complete onboarding and create your tenant, noting the **Tenant Domain**
-  </Step>
-
-  <Step title="Generate API Key">
-    Create an API key for use with Vet in your tenant settings
+  <Step title="Create a tenant">
+    Complete onboarding and create your tenant. Note the **tenant domain** (for example `your-company.safedep.io`). Tools use it to identify your tenant.
   </Step>
 </Steps>
-
-After completing onboarding, you should have:
-
-- **Tenant Domain** (e.g., `your-company.safedep.io`)
-- **API Key** for authentication
-
-See [supported integrations](/governance/integrations/overview) for more details on how to integrate with your SDLC.
-
-## Quick Onboarding with Vet CLI
-
-The quickest path is the `vet cloud quickstart` command:
-
-<Steps>
-  <Step title="Install Vet">
-    Ensure Vet is installed on your system:
-
-    ```bash
-    brew tap safedep/tap
-    brew install safedep/tap/vet
-    ```
-  </Step>
-
-  <Step title="Run Quickstart">
-    Run the command and follow the prompts:
-
-    ```bash
-    vet cloud quickstart
-    ```
-    <iframe
-      width="100%"
-      height="315"
-      src="https://www.youtube.com/embed/ykSiP547xuA"
-      title="SafeDep Cloud Quickstart"
-      frameBorder="0"
-      allowFullScreen
-    ></iframe>
-  </Step>
-</Steps>
-
-## Configure Vet with SafeDep Cloud
-
-<Info>Skip this section if you used the `vet cloud quickstart` command</Info>
-
-### Authentication Setup
-
-Configure Vet to authenticate with your SafeDep Cloud tenant:
-
-```bash
-vet auth configure --tenant <tenant-domain>
-```
-
-You'll be prompted to enter your API key securely.
-
-### Verify Authentication
-
-Confirm that your Vet instance can connect to SafeDep Cloud:
-
-```bash
-vet auth verify
-```
-
-## Sync Data to SafeDep Cloud
-
-Enable the sync reporting module to send Vet findings to SafeDep Cloud:
-
-```bash
-vet scan -M /path/to/package-lock.json --report-sync \
-  --report-sync-project my-project \
-  --report-sync-project-version my-project-version
-```
 
 <Note>
-  The example uses `package-lock.json`, but Vet supports many package manifest
-  formats and code analysis.
+You do not need to create an API key by hand. `safedep auth login` creates one during login. CI/CD integrations that need a static key can generate one at [app.safedep.io/settings/api-keys](https://app.safedep.io/settings/api-keys).
 </Note>
 
-## GitHub Actions Integration
+## Install the safedep CLI
 
-Configure [vet-action](https://github.com/safedep/vet-action) to sync with SafeDep Cloud:
-
-<Steps>
-  <Step title="Create Secrets">
-    Add these [GitHub Action Secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions):
-    - `SAFEDEP_CLOUD_API_KEY`
-    - `SAFEDEP_CLOUD_TENANT_DOMAIN`
-  </Step>
-  
-  <Step title="Update Workflow">
-    Modify your vet-action workflow:
-    ```yaml
-    - name: Run vet
-      uses: safedep/vet-action@v1
-      with:
-        cloud: true
-        cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
-        cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
+<Tabs>
+  <Tab title="Homebrew">
+    ```bash
+    brew install safedep/tap/cli
     ```
-  </Step>
-</Steps>
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm install -g @safedep/cli
+    ```
+  </Tab>
+</Tabs>
 
-## Query Your Data
+Prebuilt binaries for Linux, macOS, and Windows are on the [releases page](https://github.com/safedep/cli/releases).
 
-Once data is syncing, query your tenant's aggregated inventory and findings:
-projects, packages, endpoints, and security findings enriched with threat
-intelligence (vulnerabilities, EPSS, CISA KEV, OpenSSF Scorecard).
-
-Queries run through the [`safedep` CLI](https://github.com/safedep/cli#safedep-cli).
-For example, to find your top remediation targets by critical CVE count:
+## Log in
 
 ```bash
 safedep auth login
+```
+
+The command runs an OAuth device flow in your browser, selects a tenant you have access to, creates an API key, and stores the credentials in your OS keychain.
+
+Confirm the session:
+
+```bash
+safedep auth status
+```
+
+For static API key login, credential profiles, and non-interactive use, see the [authentication guide](/governance/cloud/authentication) and the [CLI command reference](https://github.com/safedep/cli/tree/main/docs/cmd).
+
+## Connect a data source
+
+A new tenant is empty until a tool syncs data into it. Pick the source that matches what you want to see:
+
+<CardGroup cols={2}>
+  <Card title="Repository scans" icon="magnifying-glass" href="/governance/cloud/sync">
+    Sync packages, vulnerabilities, and policy violations from `vet scan`, locally or in CI/CD
+  </Card>
+  <Card title="Package installs" icon="shield" href="/governance/cloud/endpoint-hub/package-guard">
+    Track package manager activity on developer machines with PMG
+  </Card>
+  <Card title="AI tool inventory" icon="boxes-stacked" href="/governance/cloud/endpoint-hub/inventory">
+    Discover coding agents, MCP servers, and Agent Skills on endpoints with `vet endpoint scan`
+  </Card>
+  <Card title="GitHub App" icon="github" href="/governance/integrations/github">
+    Scan pull requests with zero setup and link the installation to your tenant
+  </Card>
+</CardGroup>
+
+Once PMG or `vet endpoint scan` reports from a machine, check your fleet from the CLI:
+
+```bash
+safedep endpoint status
+```
+
+## Query your data
+
+Query your tenant's aggregated inventory and findings with SQL: projects, packages, endpoints, and security findings enriched with threat intelligence (vulnerabilities, EPSS, CISA KEV, OpenSSF Scorecard).
+
+For example, find your top remediation targets by critical CVE count:
+
+```bash
 safedep query exec --sql "
   SELECT packages.name, COUNT(DISTINCT vulnerabilities.vuln_id) AS critical_vulns
   FROM packages
@@ -162,35 +97,24 @@ safedep query exec --sql "
 ```
 
 <Note>
-Prefer a UI? You can also run queries from the web console at
-[app.safedep.io](https://app.safedep.io).
+Prefer a UI? Run the same queries from the web console at [app.safedep.io](https://app.safedep.io).
 </Note>
 
-See the **[SQL query guide](/reference/sql-query)** for the full schema, query
-rules, and worked examples: severity breakdowns, EPSS enrichment, malware
-findings, endpoint audit trails, and more.
+See the [SQL query guide](/reference/sql-query) for the full schema, query rules, and worked examples: severity breakdowns, EPSS enrichment, malware findings, endpoint audit trails, and more.
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Query with SQL" icon="magnifying-glass" href="/reference/sql-query">
-    Explore your tenant data with the `safedep` CLI
-  </Card>
   <Card title="Authentication Guide" icon="key" href="/governance/cloud/authentication">
-    Learn advanced authentication and access control
+    Cloud authentication methods and API access patterns
   </Card>
   <Card title="Malware Analysis" icon="virus" href="/governance/cloud/malware-analysis">
-    Enable enhanced threat detection capabilities
+    Detect malicious packages in your dependencies with Cloud code analysis
   </Card>
   <Card title="Cloud FAQ" icon="question-circle" href="/governance/cloud/faq">
-    Find answers to common questions
+    Answers to common questions
   </Card>
-  <Card
-    title="API Documentation"
-    icon="code"
-    href="/reference/api-introduction"
-  >
-    Integrate SafeDep Cloud with your systems
+  <Card title="API Documentation" icon="code" href="/reference/api-introduction">
+    Integrate SafeDep Cloud with your own systems
   </Card>
 </CardGroup>
-

--- a/governance/cloud/sync.mdx
+++ b/governance/cloud/sync.mdx
@@ -1,34 +1,45 @@
 ---
 title: Cloud Sync
-description: "Synchronize Vet scan data and policy violations with SafeDep Cloud for centralized analysis, query and reporting"
+description: "How vet, PMG, and vet endpoint scan send data to your SafeDep Cloud tenant, and how to set up each source"
 ---
 
-This page covers syncing `vet scan` results from CI/CD pipelines to SafeDep Cloud using `--report-sync`. To sync AI tool inventory from developer machines or agents, see [Inventory Sync](/governance/cloud/endpoint-hub/inventory).
+Your SafeDep Cloud tenant receives data from more than one tool. Each source syncs through its own path and shows up in a different part of the product:
 
-## Sync Methods
+| Source | What it sends | Where it appears |
+|---|---|---|
+| [`vet scan`](#sync-vet-scan-results) | Packages, vulnerabilities, and policy violations per project | Projects and the [SQL query tables](/reference/sql-query) |
+| [PMG](#sync-package-events-from-pmg) | Package install and usage events from endpoints | [Endpoint Hub › Package Guard](/governance/cloud/endpoint-hub/package-guard) |
+| [`vet endpoint scan`](#sync-ai-tool-inventory) | AI tools, coding agents, MCP servers, and Agent Skills found on endpoints | [Endpoint Hub › Inventory](/governance/cloud/endpoint-hub/inventory) |
+| [GitHub App](/governance/integrations/github) | Pull request scan results from repositories it is installed on | Projects |
 
-<CardGroup cols={2}>
-  <Card title="Vet CLI" icon="terminal">
-    Direct integration using command-line interface
-  </Card>
-  <Card title="vet-action" icon="github">
-    GitHub Actions workflow integration
-  </Card>
-</CardGroup>
+Every source needs SafeDep Cloud credentials: a tenant domain and an API key. New to Cloud? Start with the [quickstart](/governance/cloud/quickstart).
 
-## Using Vet CLI
+This page covers `vet scan` sync in full. PMG and endpoint inventory sync have their own setup guides, summarized below.
+
+## Sync vet scan results
+
+`vet scan --report-sync` uploads scan results to your tenant, grouped by project and version.
 
 ### Prerequisites
 
-Configure `vet` to authenticate with SafeDep Cloud before using `--report-sync`. See the [quickstart guide](/governance/cloud/quickstart) for onboarding and authentication setup.
+vet needs SafeDep Cloud credentials before it can sync. The fastest path is the guided setup, which walks through account, tenant, and credentials in one command:
 
-<Info>
-The `--report-sync` flag enables data synchronization to SafeDep Cloud.
-</Info>
+```bash
+vet cloud quickstart
+```
 
-### Basic Synchronization
+<iframe
+  width="100%"
+  height="315"
+  src="https://www.youtube.com/embed/ykSiP547xuA"
+  title="SafeDep Cloud Quickstart"
+  frameBorder="0"
+  allowFullScreen
+></iframe>
 
-Sync scan results with project identification:
+Already onboarded? See the [authentication guide](/governance/cloud/authentication#vet) to configure vet with an existing tenant and API key.
+
+### Sync a scan
 
 ```bash
 vet scan -M /path/to/package-lock.json --report-sync \
@@ -36,14 +47,10 @@ vet scan -M /path/to/package-lock.json --report-sync \
   --report-sync-project-version my-project-version
 ```
 
-### Parameters
+- `--report-sync-project`: project identifier. Use a consistent convention, like the repository path (`github.com/org/repo`), so names stay unique across teams.
+- `--report-sync-project-version`: project version, typically a branch, tag, or commit
 
-- `--report-sync-project`: Project identifier (typically repository name)
-- `--report-sync-project-version`: Project version (branch, tag, or commit)
-
-### Directory Scanning with Sync
-
-Scan entire repositories and sync results:
+Scan a whole repository the same way:
 
 ```bash
 vet scan -D /path/to/repository \
@@ -52,324 +59,199 @@ vet scan -D /path/to/repository \
   --report-sync-project-version main
 ```
 
-### Multiple Manifest Sync
+<Note>
+The examples use `package-lock.json`, but vet supports many package manifest formats and code analysis.
+</Note>
 
-Sync results from scanning multiple manifest files:
+### Separate environments
 
-```bash
-vet scan -D /path/to/monorepo \
-  --report-sync \
-  --report-sync-project monorepo-backend \
-  --report-sync-project-version v2.1.0
-```
-
-## Advanced Sync Configurations
-
-### Environment-Based Sync
-
-Differentiate between environments using project versions:
-
-<Tabs>
-  <Tab title="Production">
-    ```bash
-    vet scan -D . \
-      --report-sync \
-      --report-sync-project myapp \
-      --report-sync-project-version production
-    ```
-  </Tab>
-  
-  <Tab title="Staging">
-    ```bash
-    vet scan -D . \
-      --report-sync \
-      --report-sync-project myapp \
-      --report-sync-project-version staging
-    ```
-  </Tab>
-  
-  <Tab title="Development">
-    ```bash
-    vet scan -D . \
-      --report-sync \
-      --report-sync-project myapp \
-      --report-sync-project-version feature-branch
-    ```
-  </Tab>
-</Tabs>
-
-### Conditional Sync with Policies
-
-Sync only when policy violations are found:
+The version field also separates environments. Sync the same project as `production`, `staging`, or a feature branch name, then compare them side by side in SafeDep Cloud:
 
 ```bash
 vet scan -D . \
-  --filter-suite security-policy.yml \
+  --report-sync \
+  --report-sync-project myapp \
+  --report-sync-project-version staging
+```
+
+### Enforce policy while syncing
+
+Sync and policy enforcement run in the same scan. Add a policy suite and `--filter-fail` to gate the pipeline while results still sync to your tenant:
+
+```bash
+vet scan -D . \
+  --policy-suite policy.yml \
   --filter-fail \
   --report-sync \
   --report-sync-project critical-app \
   --report-sync-project-version main
 ```
 
-### Batch Processing
+`--policy-suite` takes a v2 policy file (see the [example in the vet repository](https://github.com/safedep/vet/blob/main/samples/policy-v2.yml)); `--filter-fail` exits non-zero on a violation. The older `--filter-suite` format is documented in the [policy reference](/reference/policy-as-code).
 
-Sync multiple projects in a script:
+### Sync from GitHub Actions
 
-```bash
-#!/bin/bash
-for project in project-a project-b project-c; do
-  vet scan -D "/path/to/$project" \
-    --report-sync \
-    --report-sync-project "$project" \
-    --report-sync-project-version "$(git -C /path/to/$project rev-parse --abbrev-ref HEAD)"
-done
-```
-
-## GitHub Actions Integration
-
-### Basic vet-action Configuration
-
-Enable cloud sync in your GitHub workflow:
+[vet-action](https://github.com/safedep/vet-action) syncs automatically when its cloud inputs are set. Add `SAFEDEP_CLOUD_API_KEY` and `SAFEDEP_CLOUD_TENANT_DOMAIN` as [GitHub Actions secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions), then enable cloud sync in your workflow:
 
 ```yaml
-name: Security Scan and Sync
-on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  security-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Run vet with cloud sync
-        uses: safedep/vet-action@v1
-        with:
-          cloud: true
-          cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
-          cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+- name: Run vet
+  uses: safedep/vet-action@v1
+  with:
+    cloud: true
+    cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
+    cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
 ```
 
-### Advanced GitHub Actions Configuration
+vet-action sets project identification from the repository: the project name is `${{ github.repository }}` and the version is `${{ github.ref_name }}`.
 
-```yaml
-name: Comprehensive Security Analysis
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  schedule:
-    - cron: '0 2 * * 1'  # Weekly scan
+### Sync from other CI systems
 
-jobs:
-  security-analysis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Run security scan with sync
-        uses: safedep/vet-action@v1
-        with:
-          cloud: true
-          cloud-key: ${{ secrets.SAFEDEP_CLOUD_API_KEY }}
-          cloud-tenant: ${{ secrets.SAFEDEP_CLOUD_TENANT_DOMAIN }}
-          policy: '.github/vet/policy.yml'
-          paranoid: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Upload scan artifacts
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: security-scan-results
-          path: |
-            *.json
-            *.sarif
-```
+The pattern is the same on any CI system: provide `SAFEDEP_API_KEY` and `SAFEDEP_TENANT_ID` as environment variables and run `vet scan` with the `--report-sync` flags. See [CI/CD & Platform Integrations](/governance/integrations/overview) for the full GitLab and Bitbucket guides.
 
-### Project Identification
+<Tabs>
+  <Tab title="GitLab CI">
+    ```yaml
+    stages:
+      - security
 
-vet-action automatically sets project identification from repository information:
+    security-scan:
+      stage: security
+      image: ghcr.io/safedep/vet:latest
+      script:
+        - vet scan -D . --report-sync --report-sync-project $CI_PROJECT_PATH --report-sync-project-version $CI_COMMIT_REF_NAME
+      variables:
+        SAFEDEP_API_KEY: $SAFEDEP_API_KEY
+        SAFEDEP_TENANT_ID: $SAFEDEP_TENANT_ID
+      only:
+        - main
+        - develop
+        - merge_requests
+    ```
+  </Tab>
 
-- **Project Name**: `${{ github.repository }}` (e.g., `org/repo`)
-- **Project Version**: `${{ github.ref_name }}` (branch or tag name)
+  <Tab title="Jenkins">
+    ```groovy
+    pipeline {
+        agent any
 
-## CI/CD Platform Integration
+        environment {
+            SAFEDEP_API_KEY = credentials('safedep-api-key')
+            SAFEDEP_TENANT_ID = credentials('safedep-tenant-id')
+        }
 
-### GitLab CI
-
-```yaml
-stages:
-  - security
-
-security-scan:
-  stage: security
-  image: ghcr.io/safedep/vet:latest
-  script:
-    - vet scan -D . --report-sync --report-sync-project $CI_PROJECT_PATH --report-sync-project-version $CI_COMMIT_REF_NAME
-  variables:
-    SAFEDEP_API_KEY: $SAFEDEP_API_KEY
-    SAFEDEP_TENANT_ID: $SAFEDEP_TENANT_ID
-  only:
-    - main
-    - develop
-    - merge_requests
-```
-
-### Jenkins Pipeline
-
-```groovy
-pipeline {
-    agent any
-    
-    environment {
-        SAFEDEP_API_KEY = credentials('safedep-api-key')
-        SAFEDEP_TENANT_ID = credentials('safedep-tenant-id')
-    }
-    
-    stages {
-        stage('Security Scan') {
-            steps {
-                sh """
-                    vet scan -D . \
-                      --report-sync \
-                      --report-sync-project ${env.JOB_NAME} \
-                      --report-sync-project-version ${env.BRANCH_NAME}
-                """
+        stages {
+            stage('Security Scan') {
+                steps {
+                    sh """
+                        vet scan -D . \
+                          --report-sync \
+                          --report-sync-project ${env.JOB_NAME} \
+                          --report-sync-project-version ${env.BRANCH_NAME}
+                    """
+                }
             }
         }
     }
-}
-```
+    ```
+  </Tab>
 
-### Azure DevOps
+  <Tab title="Azure DevOps">
+    ```yaml
+    trigger:
+      branches:
+        include:
+          - main
+          - develop
 
-```yaml
-trigger:
-  branches:
-    include:
-      - main
-      - develop
+    variables:
+      - group: safedep-credentials
 
-variables:
-  - group: safedep-credentials
+    jobs:
+    - job: SecurityScan
+      displayName: 'Security Scan and Sync'
+      pool:
+        vmImage: 'ubuntu-latest'
 
-jobs:
-- job: SecurityScan
-  displayName: 'Security Scan and Sync'
-  pool:
-    vmImage: 'ubuntu-latest'
-  
-  steps:
-  - script: |
-      vet scan -D . \
-        --report-sync \
-        --report-sync-project $(Build.Repository.Name) \
-        --report-sync-project-version $(Build.SourceBranchName)
-    displayName: 'Run vet security scan'
-    env:
-      SAFEDEP_API_KEY: $(safedep-api-key)
-      SAFEDEP_TENANT_ID: $(safedep-tenant-id)
-```
+      steps:
+      - script: |
+          vet scan -D . \
+            --report-sync \
+            --report-sync-project $(Build.Repository.Name) \
+            --report-sync-project-version $(Build.SourceBranchName)
+        displayName: 'Run vet security scan'
+        env:
+          SAFEDEP_API_KEY: $(safedep-api-key)
+          SAFEDEP_TENANT_ID: $(safedep-tenant-id)
+    ```
+  </Tab>
+</Tabs>
 
-## Data Synchronization Details
-
-### What Gets Synced
+### What gets synced
 
 <AccordionGroup>
-  <Accordion title="Package Information">
-    - All discovered packages and versions
+  <Accordion title="Package information">
+    - Discovered packages and versions
     - Dependency relationships and metadata
     - Package manifest locations and types
   </Accordion>
-  
-  <Accordion title="Security Findings">
+
+  <Accordion title="Security findings">
     - Vulnerability information and severity levels
     - OpenSSF Scorecard metrics
     - License compliance data
     - Malware analysis results (if enabled)
   </Accordion>
-  
-  <Accordion title="Policy Violations">
+
+  <Accordion title="Policy violations">
     - Policy rule violations and details
-    - Filter expression results
     - Exception applications and status
   </Accordion>
-  
-  <Accordion title="Project Context">
+
+  <Accordion title="Project context">
     - Project identification and versioning
     - Scan timestamps and environment info
     - Git commit information (when available)
   </Accordion>
 </AccordionGroup>
 
-### Sync Frequency
+## Sync package events from PMG
 
-- **On-demand**: Manual scans using the CLI
-- **CI/CD triggered**: Automated scans on code changes
-- **Scheduled**: Regular scans via cron or scheduled workflows
-- **Event-driven**: Scans triggered by specific events
+[PMG](/package-security/pmg/overview) intercepts package manager commands on the endpoint and records each install as an event. With cloud sync enabled, PMG drains its local event log to your tenant automatically after each invocation, and `pmg cloud sync` pushes events immediately.
 
-## Querying Synced Data
+Setup, login, and auto-sync tuning live on the Package Guard page:
 
-Once data is synced to SafeDep Cloud, query it with the `safedep` CLI:
+<Card title="Package Guard" icon="shield" href="/governance/cloud/endpoint-hub/package-guard" horizontal>
+  Enable PMG cloud sync and view package events in Endpoint Hub
+</Card>
 
-```bash
-safedep query exec --sql "
-  SELECT projects.name
-  FROM projects
-  WHERE projects.origin_source = 'SOURCE_GITHUB'
-  ORDER BY projects.name"
-```
+## Sync AI tool inventory
 
-See the [SafeDep Cloud SQL guide](/reference/sql-query) for the full schema, the join model, and worked examples covering vulnerabilities, licenses, malware findings, and endpoint events.
+`vet endpoint scan` discovers AI tooling on a machine (coding agents, MCP servers, CLI tools, IDE extensions, Agent Skills) and delivers the inventory to your tenant when vet has credentials configured.
 
-## Best Practices
+<Card title="Endpoint Inventory" icon="boxes-stacked" href="/governance/cloud/endpoint-hub/inventory" horizontal>
+  Enable inventory sync and browse discovered AI tooling in Endpoint Hub
+</Card>
 
-<AccordionGroup>
-  <Accordion title="Project Naming">
-    Use consistent naming:
-    - Include the organization: `org/project-name`
-    - Use repository URLs for uniqueness across teams
-  </Accordion>
-  
-  <Accordion title="Version Management">
-    Use meaningful version identifiers:
-    - Branch names for development branches
-    - Semantic versions for releases
-    - Environment identifiers (prod, staging, dev)
-  </Accordion>
-  
-  <Accordion title="Sync Strategy">
-    - Sync on every commit to the main branch
-    - Include pull request scans for early detection
-    - Add scheduled scans to catch drift between commits
-  </Accordion>
-</AccordionGroup>
+## Query synced data
+
+Once data lands in your tenant, query it with `safedep query exec` or the web console. The [quickstart](/governance/cloud/quickstart#query-your-data) has a worked example, and the [SQL query guide](/reference/sql-query) covers the full schema, join model, and queries across vulnerabilities, licenses, malware findings, and endpoint events.
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Sync Failures">
-    - Verify the API key and tenant configuration
+  <Accordion title="Sync failures">
+    - Verify the API key and tenant configuration (`vet auth verify`)
     - Check network connectivity to SafeDep Cloud
     - Ensure project names don't contain invalid characters
   </Accordion>
-  
-  <Accordion title="Missing Data">
+
+  <Accordion title="Missing data">
     - Confirm `--report-sync` and the project flags are set
     - Check that the scan completed successfully
     - Verify the project name and version identifiers match what you expect
   </Accordion>
-  
-  <Accordion title="Authentication Issues">
+
+  <Accordion title="Authentication issues">
     - Verify the API key has sync permissions
     - Check the tenant domain configuration
     - Confirm credentials are set correctly in your CI/CD environment
@@ -378,15 +260,15 @@ See the [SafeDep Cloud SQL guide](/reference/sql-query) for the full schema, the
 
 <CardGroup cols={2}>
   <Card title="Cloud Quickstart" icon="rocket" href="/governance/cloud/quickstart">
-    Get started with SafeDep Cloud authentication and setup
+    Set up the safedep CLI and run your first query
+  </Card>
+  <Card title="Authentication Guide" icon="key" href="/governance/cloud/authentication">
+    SafeDep Cloud authentication methods
+  </Card>
+  <Card title="Endpoint Hub" icon="server" href="/governance/cloud/endpoint-hub/overview">
+    AI tooling and package activity across your endpoints
   </Card>
   <Card title="vet-action Documentation" icon="github" href="https://github.com/safedep/vet-action">
     Complete GitHub Actions integration guide
-  </Card>
-  <Card title="Cloud Queries" icon="search" href="/governance/cloud/quickstart#query-your-data">
-    Learn how to query synced data in SafeDep Cloud
-  </Card>
-  <Card title="Authentication Guide" icon="key" href="/governance/cloud/authentication">
-    Understand SafeDep Cloud authentication methods
   </Card>
 </CardGroup>

--- a/reference/api-introduction.mdx
+++ b/reference/api-introduction.mdx
@@ -1,22 +1,54 @@
 ---
 title: "API Reference"
-description: 'Getting started with SafeDep API'
+description: "SafeDep Cloud API: transport, request headers, OAuth2/OIDC endpoints, and rate limits"
 ---
 
 SafeDep supports a [gRPC](https://grpc.io/) API with
 a [ConnectRPC](https://connectrpc.com/) facade allowing clients to use both
 gRPC over HTTP/2 and JSON over HTTP/1.1 based clients.
 
-Authentication uses [OAuth 2.0](https://oauth.net/2/) or API keys, depending on the plane:
+The canonical API specification lives at [buf.build/safedep/api](https://buf.build/safedep/api), which also publishes generated SDKs for all supported languages.
 
-* Control plane APIs (e.g. creating policy) require OAuth 2.0 authentication.
-* Data plane APIs (e.g. getting policy data) accept API keys.
+## Planes and authentication
 
-Control plane APIs are for management tooling; data plane APIs are for security tools that use or integrate with SafeDep.
+* Control plane APIs (`cloud.safedep.io`, e.g. creating policy) require OAuth 2.0 authentication (JWT).
+* Data plane APIs (`api.safedep.io`, e.g. package insights) accept API keys or JWTs.
+
+Control plane APIs are for management tooling; data plane APIs are for security tools that use or integrate with SafeDep. For tool-level login flows (safedep CLI, vet, CI/CD), see the [authentication guide](/governance/cloud/authentication).
+
+## Request headers
+
+Regardless of transport (gRPC over HTTP/2 or JSON over HTTP/1.1), requests carry the same two headers:
+
+| Header | Value |
+|--------|-------|
+| `Authorization` | Your API key or JWT, sent **as-is** (no `Bearer` prefix) |
+| `X-Tenant-ID` | Your tenant domain (e.g. `your-company.safedep.io`) |
+
+## OAuth2 / OIDC
+
+The SafeDep Cloud Identity Service at `https://auth.safedep.io` provides OAuth2/OIDC authentication for the control plane.
+
+**OpenID configuration endpoint:**
+
+```
+https://auth.safedep.io/.well-known/openid-configuration
+```
+
+Command-line tools authenticate with the OAuth2 Device Code flow. A reference implementation is available in the [vet OAuth2 client](https://github.com/safedep/vet/blob/main/cmd/cloud/login.go).
+
+## Rate limiting
+
+SafeDep Cloud enforces rate limits at the API gateway, measured **per second**, with no hourly quota:
+
+- **Data plane** (`api.safedep.io`): up to **500 requests/second** per API key
+- **Management API**: up to **20 requests/second**
+
+These limits are subject to change.
 
 <CardGroup cols={2}>
   <Card title="Authentication" icon="key" href="/governance/cloud/authentication">
-    API key and OAuth/JWT authentication for the API.
+    API key and OAuth/JWT authentication for the safedep CLI, vet, and CI/CD.
   </Card>
   <Card title="API Hosts" icon="server" href="/reference/endpoints">
     Control plane, data plane, and other SafeDep hosts.
@@ -28,4 +60,3 @@ Control plane APIs are for management tooling; data plane APIs are for security 
     Query your tenant data with SQL.
   </Card>
 </CardGroup>
-


### PR DESCRIPTION
Closes #67.

Leads the Cloud quickstart with the `safedep` CLI and makes the sync page source-aware, then removes the duplication this created so each command has one home.

## Changes

- **quickstart**: `safedep` CLI first (account/tenant → install → `auth login` → connect a source → query). Canonical home for the worked `safedep query exec` example. `vet cloud quickstart` and its video moved to sync.
- **sync**: source map (a table of all producers and where each surfaces) + full home for `vet scan --report-sync`. PMG and endpoint inventory are pointer sections into their Endpoint Hub homes, not restated setup. Policy example rewritten to `--policy-suite`; GitLab/Jenkins/Azure kept in tabs.
- **authentication**: slimmed to per-tool auth (safedep CLI, vet, CI/CD). API-level detail (headers, OAuth2/OIDC, rate limits) moved to the Reference tab. Troubleshooting headings reworded from raw error strings to the problem.
- **reference/api-introduction**: absorbed the API-level auth reference.
- **faq**: rate-limit link repointed.

## Verification

- Commands checked against `../vet` and `../cli` source.
- `broken-links` clean apart from the three pre-existing `essentials/` failures.
- No em-dashes; cross-page anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)