### PR TITLE
Document on-demand package scanning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository contains documentation for SafeDep, built using Mintlify documen
 The documentation is organized into **6 tabs** — three solution tabs at the core, plus supporting tabs:
 
 1. **Get Started** — "What is SafeDep?" primer, quickstarts, core concepts
-2. **Package Security** — block malicious packages at install time and in CI/CD (pmg)
+2. **Package Security** — block malicious packages at install time and in CI/CD, and scan any package, extension, or repo on demand before use (pmg, safedep CLI)
 3. **AI Agent Security** — discover, audit, and control what AI agents access and run (MCP, Gryph, vet AI discovery)
 4. **Visibility & Governance** — scan repos/SBOMs/CI/CD for risk; manage policy and cloud visibility (vet, xBom, SafeDep Cloud, Endpoint Hub, Endpoint Sync)
 5. **Reference** — exact syntax/APIs (vet query & policy, API & automation)
@@ -45,6 +45,7 @@ Every placement decision derives from these rules. Full rationale and page map: 
 | Defines a concept/term used across docs | Get Started | Core Concepts |
 | Onboards a new user / routes entry points | Get Started | Introduction (product quickstarts co-locate with their product) |
 | Covers malicious package blocking (install-time or CI/CD) | Package Security | pmg / CI/CD Package Blocking |
+| Covers evaluating a package/extension/repo before use (on-demand scanning) | Package Security | On-Demand Package Scanning |
 | Covers AI agent discovery, audit, or control | AI Agent Security | AI Agent Observability / AI Coding Protection |
 | Covers scanning repos, SBOMs, CI/CD for risk | Visibility & Governance | Repository Scanning / Bill of Materials / CI/CD |
 | Covers cloud policy, endpoint inventory, access | Visibility & Governance | SafeDep Cloud / Endpoint Hub / Policy & Risk |

--- a/docs-ia.md
+++ b/docs-ia.md
@@ -13,7 +13,7 @@ Six tabs — three solution tabs at the core, plus supporting tabs.
 | Tab | Purpose | Groups |
 |---|---|---|
 | **Get Started** | What is SafeDep, vocabulary, entry points | Introduction · Core Concepts |
-| **Package Security** | Block malicious packages at install time — on dev machines and in CI/CD | Install-Time Package Blocking · CI/CD Package Blocking |
+| **Package Security** | Block malicious packages at install time — on dev machines and in CI/CD — and scan any component on demand before use | Install-Time Package Blocking · On-Demand Package Scanning · CI/CD Package Blocking |
 | **AI Agent Security** | Discover, audit, and control what AI agents access and run | AI Agent Observability · AI Coding Protection |
 | **Visibility & Governance** | Scan repos, SBOMs, and CI/CD for supply-chain risk; manage policy and org-wide cloud visibility | Repository Scanning · Bill of Materials · CI/CD & Platform Integrations · SafeDep Cloud (nests Endpoint Hub, Policy & Risk, Authentication) |
 | **Reference** | Exact syntax, flags, API specs — no explanation | Query & Policy · API & Automation |
@@ -56,6 +56,7 @@ Every structural decision derives from these rules. Full rationale in `docs-ia-p
 | Defines a concept/term used across docs | Get Started | Core Concepts |
 | Onboards a new user / routes entry points | Get Started | Introduction (product quickstarts co-locate with their product) |
 | Covers malicious package blocking (install-time or CI/CD) | Package Security | pmg / CI/CD Package Blocking |
+| Covers evaluating a package/extension/repo before use (on-demand scanning) | Package Security | On-Demand Package Scanning |
 | Covers AI agent discovery, audit, or control | AI Agent Security | AI Agent Observability / AI Coding Protection |
 | Covers scanning repos, SBOMs, or CI/CD for supply-chain risk | Visibility & Governance | Repository Scanning / Bill of Materials / CI/CD |
 | Covers cloud policy, endpoint inventory, or org-wide access | Visibility & Governance | SafeDep Cloud / Endpoint Hub / Policy & Risk |
@@ -133,7 +134,8 @@ Don't mix Diátaxis types within a single page.
 
 **Package Security** *(tab landing: `package-security/overview`)*
 - Install-Time Package Blocking: `package-security/pmg/overview` *(landing)*, `package-security/pmg/quickstart`, `package-security/pmg/system-install`
-- CI/CD Package Blocking: `package-security/jfrog-xray`
+- On-Demand Package Scanning: `package-security/scan/overview` *(landing)*, `package-security/scan/quickstart`, `package-security/scan/automation`
+- CI/CD Package Blocking: `package-security/pmg/github-actions`, `package-security/jfrog-xray`
 
 **AI Agent Security** *(tab landing: `ai-security/overview`)* — flat list, scoped to securing AI coding *agents*. The "AI as a software component" pages (Shadow AI in Code, AI Governance) moved to Visibility & Governance, since AI SDKs in your app are a supply-chain concern, not agent security. Order is discover → observe → augment.
 - `ai-security/ai-tools-discovery`, `ai-security/gryph-overview`, `ai-security/mcp-server`
@@ -141,9 +143,9 @@ Don't mix Diátaxis types within a single page.
 **Visibility & Governance** *(tab landing: `governance/overview`)*
 - Repository Scanning: `governance/vet/overview` *(landing)*, `governance/vet/quickstart`, `governance/vet/dependency-inventory`, `governance/vet/dependency-usage`, `governance/vet/code-analysis`
 - Bill of Materials: `governance/xbom/overview` *(landing)*, `governance/xbom/quickstart`, `governance/cyclonedx-sbom`
-- AI Visibility: `governance/ai-governance` *(landing)*, `governance/shadow-ai-detection`
+- AI Visibility: `governance/ai-governance` *(landing)*, `governance/shadow-ai-detection`, `governance/vet/ai-bom`
 - CI/CD & Platform Integrations: `governance/integrations/overview` *(landing)*, `governance/integrations/github`, `governance/integrations/github-code-scanning`, `governance/integrations/gitlab`, `governance/integrations/bitbucket`, `governance/integrations/defectdojo`, `governance/terraform-audit`
-- SafeDep Cloud: `governance/cloud/overview` *(landing)*, `governance/cloud/quickstart`, `governance/cloud/authentication`, `governance/cloud/sync`, `governance/cloud/alerts`
+- SafeDep Cloud: `governance/cloud/overview` *(landing)*, `governance/cloud/quickstart`, `governance/cloud/authentication`, `governance/cloud/usage-billing`, `governance/cloud/sync`, `governance/cloud/talk-to-safedep`, `governance/cloud/alerts`
   - Endpoint Hub: `governance/cloud/endpoint-hub/overview` *(landing)*, `governance/cloud/endpoint-hub/inventory`, `governance/cloud/endpoint-hub/inventory-catalog`, `governance/cloud/endpoint-hub/package-guard`, `governance/cloud/endpoint-hub/mcp-advisor`
   - Policy & Risk: `governance/cloud/malware-analysis`, `governance/cloud/package-exclusions`
 
@@ -155,7 +157,7 @@ Don't mix Diátaxis types within a single page.
 - Community: `community`
 - Support: `faq`, `governance/cloud/faq`
 
-Total: **58 pages**
+Total: **67 pages**
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -55,6 +55,15 @@
             ]
           },
           {
+            "group": "On-Demand Package Scanning",
+            "icon": "microscope",
+            "root": "package-security/scan/overview",
+            "pages": [
+              "package-security/scan/quickstart",
+              "package-security/scan/automation"
+            ]
+          },
+          {
             "group": "CI/CD Package Blocking",
             "icon": "shield-check",
             "pages": [
@@ -128,6 +137,7 @@
             "pages": [
               "governance/cloud/quickstart",
               "governance/cloud/authentication",
+              "governance/cloud/usage-billing",
               "governance/cloud/sync",
               "governance/cloud/talk-to-safedep",
               "governance/cloud/alerts",

--- a/get-started/cli-tools.mdx
+++ b/get-started/cli-tools.mdx
@@ -20,8 +20,11 @@ SafeDep ships several command-line tools. Each one solves a different supply-cha
   <Card title="Generate a Bill of Materials" icon="boxes-stacked" href="/governance/xbom/quickstart">
     Use **xBom** to inventory dependencies plus AI and SaaS usage detected from your source code, as a CycloneDX BOM.
   </Card>
+  <Card title="Deep-scan a package before using it" icon="microscope" href="/package-security/scan/overview">
+    Use **safedep package scan** to run a fresh malware analysis of any package, IDE extension, or GitHub repository. Needs a SafeDep Cloud paid plan or trial.
+  </Card>
   <Card title="Work with SafeDep Cloud" icon="cloud" href="https://github.com/safedep/cli">
-    Use **safedep**, the unified CLI for SafeDep Cloud: authentication, endpoint telemetry queries, and AI agent hardening. It is new and still evolving.
+    Use **safedep**, the unified CLI for SafeDep Cloud: authentication, on-demand package scanning, endpoint telemetry queries, and AI agent hardening. It is new and still evolving.
   </Card>
 </CardGroup>
 
@@ -33,7 +36,7 @@ SafeDep ships several command-line tools. Each one solves a different supply-cha
 | **PMG** | Block malicious packages at install time on the dev machine | No | Yes |
 | **Gryph** | Local audit trail for AI coding agents | No (fully local) | Yes |
 | **xBom** | Generate a BOM enriched with AI and SaaS usage from source code | No | Yes |
-| **safedep** | Manage and query SafeDep Cloud from the terminal | Yes (SafeDep Cloud) | Yes |
+| **safedep** | On-demand package scanning; manage and query SafeDep Cloud from the terminal | Yes (SafeDep Cloud) | Yes |
 
 <Note>
 Vet, PMG, and Gryph are free, open source, and work with no SafeDep account. The **safedep** CLI is the client for SafeDep Cloud's hosted features. See [pricing](https://safedep.io/pricing).
@@ -43,7 +46,7 @@ Vet, PMG, and Gryph are free, open source, and work with no SafeDep account. The
 
 - **Vet** is the scanning engine. It analyzes dependencies and produces risk reports, queries, and SBOMs. It runs standalone or syncs results to SafeDep Cloud.
 - **PMG** and **Gryph** are standalone, single-purpose guards. PMG works at package-install time, Gryph around AI coding agents. Neither needs Vet or a SafeDep account.
-- **safedep** is an emerging unified CLI that brings SafeDep Cloud's workflows (auth, endpoint telemetry, agent hardening) to the terminal. It orchestrates the tools above and the Cloud APIs rather than re-implementing scanning, so the analysis stays in the upstream tools.
+- **safedep** is an emerging unified CLI that brings SafeDep Cloud's workflows (auth, [on-demand package scanning](/package-security/scan/overview), endpoint telemetry, agent hardening) to the terminal. It does not re-implement local scanning: repository analysis stays in Vet, and on-demand package analysis runs in SafeDep Cloud.
 
 <Info>
 These tools have no "v1 to v2" relationship. `safedep` is a new Cloud-focused CLI, not a replacement for `vet`. Vet stays the standalone scanner and the recommended starting point for most users.

--- a/get-started/cli-tools.mdx
+++ b/get-started/cli-tools.mdx
@@ -21,7 +21,7 @@ SafeDep ships several command-line tools. Each one solves a different supply-cha
     Use **xBom** to inventory dependencies plus AI and SaaS usage detected from your source code, as a CycloneDX BOM.
   </Card>
   <Card title="Deep-scan a package before using it" icon="microscope" href="/package-security/scan/overview">
-    Use **safedep package scan** to run a fresh malware analysis of any package, IDE extension, or GitHub repository. Needs a SafeDep Cloud paid plan or trial.
+    Use **safedep package scan** to run an on-demand malware analysis of any package, IDE extension, or GitHub repository. Needs a SafeDep Cloud paid plan or trial.
   </Card>
   <Card title="Work with SafeDep Cloud" icon="cloud" href="https://github.com/safedep/cli">
     Use **safedep**, the unified CLI for SafeDep Cloud: authentication, on-demand package scanning, endpoint telemetry queries, and AI agent hardening. It is new and still evolving.
@@ -36,7 +36,7 @@ SafeDep ships several command-line tools. Each one solves a different supply-cha
 | **PMG** | Block malicious packages at install time on the dev machine | No | Yes |
 | **Gryph** | Local audit trail for AI coding agents | No (fully local) | Yes |
 | **xBom** | Generate a BOM enriched with AI and SaaS usage from source code | No | Yes |
-| **safedep** | On-demand package scanning; manage and query SafeDep Cloud from the terminal | Yes (SafeDep Cloud) | Yes |
+| **safedep** | On-demand package scanning, plus managing and querying SafeDep Cloud from the terminal | Yes (SafeDep Cloud) | Yes |
 
 <Note>
 Vet, PMG, and Gryph are free, open source, and work with no SafeDep account. The **safedep** CLI is the client for SafeDep Cloud's hosted features. See [pricing](https://safedep.io/pricing).

--- a/governance/cloud/authentication.mdx
+++ b/governance/cloud/authentication.mdx
@@ -5,8 +5,8 @@ description: "How SafeDep Cloud authentication works and how to authenticate the
 
 Every tool that talks to SafeDep Cloud authenticates with two values: a **tenant domain** (for example `your-company.safedep.io`) and a credential. The credential type depends on which API plane the tool calls:
 
-- **Data plane** (`api.safedep.io`): package insights, scanning, and sync. Authenticates with an **API key**.
-- **Control plane** (`cloud.safedep.io`): tenant, policy, and management operations, including SQL queries. Authenticates with a **JWT** from an OAuth2 login.
+- **Data plane** (`api.safedep.io`): package insights, known-malicious package queries, and sync. Authenticates with an **API key**.
+- **Control plane** (`cloud.safedep.io`): tenant, policy, and management operations, including SQL queries and [on-demand package scans](/package-security/scan/overview). Authenticates with a **JWT** from an OAuth2 login.
 
 Generate API keys at [app.safedep.io/settings/api-keys](https://app.safedep.io/settings/api-keys). For request headers, OAuth2/OIDC endpoints, and rate limits, see the [API reference](/reference/api-introduction). For the full hostname list, see the [endpoints reference](/reference/endpoints).
 
@@ -26,6 +26,10 @@ safedep auth login --api-key --tenant your-company.safedep.io
 ```
 
 The key is read from `--api-key-value`, stdin (with `--from-stdin`), the `SAFEDEP_API_KEY` environment variable, or an interactive prompt, in that order. Work with multiple tenants using `--profile` and `safedep auth profile list`. See the [CLI command reference](https://github.com/safedep/cli/tree/main/docs/cmd) for all flags.
+
+<Note>
+API-key login covers data-plane commands only. [On-demand package scanning](/package-security/scan/overview) is a control-plane operation: it requires the OAuth2 device-flow session, and an API key cannot submit scans, by design. See [Scanning from CI and AI Agents](/package-security/scan/automation) for the reasoning and what this means for automation.
+</Note>
 
 ## vet
 

--- a/governance/cloud/malware-analysis.mdx
+++ b/governance/cloud/malware-analysis.mdx
@@ -8,7 +8,7 @@ description: "Detect malicious packages in your dependencies by querying SafeDep
 Check your open source dependencies against SafeDep's continuously updated database of known malicious packages using [Vet](https://github.com/safedep/vet). Vet queries SafeDep's threat intelligence service, which is populated through continuous static and dynamic analysis of packages from public registries.
 
 <Note>
-This page covers the **fast path**: a free lookup against SafeDep's database of known malicious packages, built into Vet, PMG, and the SafeDep MCP server. It answers in milliseconds but only covers packages SafeDep has already analyzed. To run a **fresh analysis** of a specific component (any package version, an IDE extension, or a GitHub repository), use [On-Demand Package Scanning](/package-security/scan/overview), an independent paid feature. Vet itself no longer submits packages for analysis; on-demand scanning moved to `safedep package scan`.
+This page covers the **fast path**: a free lookup against SafeDep's database of known malicious packages, built into Vet, PMG, and the SafeDep MCP server. It answers in milliseconds but only covers packages SafeDep has already analyzed. To run a **new analysis** of a specific component (any package version, an IDE extension, or a GitHub repository), use [On-Demand Package Scanning](/package-security/scan/overview), an independent paid feature. Vet itself no longer submits packages for analysis. On-demand scanning moved to `safedep package scan`.
 </Note>
 
 ## Supported Ecosystems
@@ -221,7 +221,7 @@ pipeline {
 
 <CardGroup cols={2}>
   <Card title="On-Demand Package Scanning" icon="microscope" href="/package-security/scan/overview">
-    Run a fresh analysis of a package, IDE extension, or GitHub repository not yet in the database
+    Run an on-demand analysis of a package, IDE extension, or GitHub repository not yet in the database
   </Card>
   <Card title="vet-action Documentation" icon="github" href="https://github.com/safedep/vet-action?tab=readme-ov-file#cloud-mode">
     Complete GitHub Actions integration guide

--- a/governance/cloud/malware-analysis.mdx
+++ b/governance/cloud/malware-analysis.mdx
@@ -8,7 +8,7 @@ description: "Detect malicious packages in your dependencies by querying SafeDep
 Check your open source dependencies against SafeDep's continuously updated database of known malicious packages using [Vet](https://github.com/safedep/vet). Vet queries SafeDep's threat intelligence service, which is populated through continuous static and dynamic analysis of packages from public registries.
 
 <Note>
-Active (on-demand) analysis of arbitrary packages has been retired. Vet now performs a fast lookup against known malicious packages instead of submitting packages for analysis and waiting for results.
+This page covers the **fast path**: a free lookup against SafeDep's database of known malicious packages, built into Vet, PMG, and the SafeDep MCP server. It answers in milliseconds but only covers packages SafeDep has already analyzed. To run a **fresh analysis** of a specific component (any package version, an IDE extension, or a GitHub repository), use [On-Demand Package Scanning](/package-security/scan/overview), an independent paid feature. Vet itself no longer submits packages for analysis; on-demand scanning moved to `safedep package scan`.
 </Note>
 
 ## Supported Ecosystems
@@ -220,6 +220,9 @@ pipeline {
 </AccordionGroup>
 
 <CardGroup cols={2}>
+  <Card title="On-Demand Package Scanning" icon="microscope" href="/package-security/scan/overview">
+    Run a fresh analysis of a package, IDE extension, or GitHub repository not yet in the database
+  </Card>
   <Card title="vet-action Documentation" icon="github" href="https://github.com/safedep/vet-action?tab=readme-ov-file#cloud-mode">
     Complete GitHub Actions integration guide
   </Card>

--- a/governance/cloud/usage-billing.mdx
+++ b/governance/cloud/usage-billing.mdx
@@ -1,0 +1,76 @@
+---
+title: Usage & On-Demand Billing
+description: "How SafeDep Cloud seat allowances and usage-based on-demand billing work, and the CLI commands to inspect and manage them."
+---
+
+Paid SafeDep Cloud plans include a monthly usage allowance for metered features. This page explains how the allowance is counted, what happens when you reach it, and how to opt in to usage-based billing beyond it.
+
+## How allowances work
+
+A metered feature's monthly allowance is a per-seat amount multiplied by your subscription's seats, pooled across the whole tenant. Any member can consume from the shared pool; there is no per-user split. The allowance resets each billing period.
+
+[On-demand package scans](/package-security/scan/overview) are metered this way today. Per-seat amounts and unit prices are listed on the [pricing page](https://safedep.io/pricing).
+
+## Check your usage
+
+```bash
+safedep subscription ondemand status
+```
+
+The output shows, per metered feature:
+
+- **Included limit and consumed**: the pooled allowance for the current period and how much of it is used.
+- **Period end**: when the allowance resets.
+- **Overage**: units consumed beyond the allowance this period, and their billed value, when on-demand billing is enabled.
+
+It also shows the account-level state: whether on-demand billing is enabled, whether a payment method is on file, and the payment posture.
+
+## What happens at the allowance limit
+
+- **On-demand billing disabled** (the default): requests beyond the allowance are denied until the period resets or you add seats.
+- **On-demand billing enabled**: usage beyond the allowance is billed per unit, up to a monthly spending cap.
+
+## Enable on-demand billing
+
+Prerequisites: an active paid subscription with a payment method on file. Add a payment method through the billing portal if needed:
+
+```bash
+safedep subscription portal open
+```
+
+Then opt in:
+
+```bash
+safedep subscription ondemand enable --accept-terms
+```
+
+The `--accept-terms` flag records your acceptance of the on-demand billing [terms](https://safedep.io/terms/), including the terms version, for the tenant account. Without the flag, the command prints the terms location and makes no change.
+
+## The spending cap
+
+On-demand billing has a monthly spending cap that bounds how much overage can be billed in a period. When the cap is reached, further over-allowance requests are denied until the period resets, so a runaway automation cannot create an unbounded bill. The default cap is listed on the [pricing page](https://safedep.io/pricing); contact [support](mailto:support@safedep.io) to adjust it.
+
+## Disable on-demand billing
+
+```bash
+safedep subscription ondemand disable
+```
+
+Overage billing stops and the included allowance limits apply again. Usage already billed in the current period remains payable.
+
+## Invoices and payment methods
+
+The billing portal handles payment methods, invoices, and billing history:
+
+```bash
+safedep subscription portal open
+```
+
+<CardGroup cols={2}>
+  <Card title="On-Demand Package Scanning" icon="microscope" href="/package-security/scan/overview">
+    The metered feature this page's allowances apply to.
+  </Card>
+  <Card title="Pricing" icon="tag" href="https://safedep.io/pricing">
+    Plans, per-seat allowances, and unit prices.
+  </Card>
+</CardGroup>

--- a/governance/cloud/usage-billing.mdx
+++ b/governance/cloud/usage-billing.mdx
@@ -5,9 +5,13 @@ description: "How SafeDep Cloud seat allowances and usage-based on-demand billin
 
 Paid SafeDep Cloud plans include a monthly usage allowance for metered features. This page explains how the allowance is counted, what happens when you reach it, and how to opt in to usage-based billing beyond it.
 
+<Note>
+The commands on this page use the `safedep` CLI. New to it? See [SafeDep CLI Tools](/get-started/cli-tools) for what it is and how to install it.
+</Note>
+
 ## How allowances work
 
-A metered feature's monthly allowance is a per-seat amount multiplied by your subscription's seats, pooled across the whole tenant. Any member can consume from the shared pool; there is no per-user split. The allowance resets each billing period.
+A metered feature's monthly allowance is a per-seat amount multiplied by your subscription's seats, pooled across the whole tenant. Any member can consume from the shared pool. There is no per-user split. The allowance resets each billing period.
 
 [On-demand package scans](/package-security/scan/overview) are metered this way today. Per-seat amounts and unit prices are listed on the [pricing page](https://safedep.io/pricing).
 
@@ -48,7 +52,7 @@ The `--accept-terms` flag records your acceptance of the on-demand billing [term
 
 ## The spending cap
 
-On-demand billing has a monthly spending cap that bounds how much overage can be billed in a period. When the cap is reached, further over-allowance requests are denied until the period resets, so a runaway automation cannot create an unbounded bill. The default cap is listed on the [pricing page](https://safedep.io/pricing); contact [support](mailto:support@safedep.io) to adjust it.
+On-demand billing has a monthly spending cap that bounds how much overage can be billed in a period. When the cap is reached, further over-allowance requests are denied until the period resets, so a runaway automation cannot create an unbounded bill. The default cap is listed on the [pricing page](https://safedep.io/pricing). Contact [support](mailto:support@safedep.io) to adjust it.
 
 ## Disable on-demand billing
 

--- a/package-security/overview.mdx
+++ b/package-security/overview.mdx
@@ -16,7 +16,7 @@ Stop malicious open-source packages before they reach your code. SafeDep blocks 
     Stop malicious packages in your JFrog artifact registry with SafeDep.
   </Card>
   <Card title="Scan a package on demand" icon="microscope" href="/package-security/scan/overview">
-    Run a fresh malware analysis of any package, IDE extension, or GitHub repository before you use it.
+    Run an on-demand malware analysis of any package, IDE extension, or GitHub repository before you use it.
   </Card>
 </CardGroup>
 

--- a/package-security/overview.mdx
+++ b/package-security/overview.mdx
@@ -3,7 +3,7 @@ title: Package Security
 description: "Block malicious open-source packages before they reach your code, on developer machines and in CI/CD."
 ---
 
-Stop malicious open-source packages before they reach your code. SafeDep blocks known-bad packages wherever they enter: a developer's install, your CI/CD pipeline, or your artifact registry.
+Stop malicious open-source packages before they reach your code. SafeDep blocks known-bad packages wherever they enter: a developer's install, your CI/CD pipeline, or your artifact registry. And when a component is not in the known-bad database yet, you can scan it on demand before adopting it.
 
 <CardGroup cols={2}>
   <Card title="Block at install time" icon="box" href="/package-security/pmg/overview">
@@ -14,6 +14,9 @@ Stop malicious open-source packages before they reach your code. SafeDep blocks 
   </Card>
   <Card title="Block in JFrog Xray" icon="shield-halved" href="/package-security/jfrog-xray">
     Stop malicious packages in your JFrog artifact registry with SafeDep.
+  </Card>
+  <Card title="Scan a package on demand" icon="microscope" href="/package-security/scan/overview">
+    Run a fresh malware analysis of any package, IDE extension, or GitHub repository before you use it.
   </Card>
 </CardGroup>
 

--- a/package-security/scan/automation.mdx
+++ b/package-security/scan/automation.mdx
@@ -75,7 +75,55 @@ A CLI timeout does not fail the scan. `scan run` waits up to 5 minutes by defaul
 
 ## Direct API access
 
-The CLI is a thin client over `PackageScanService` (`SubmitScan`, `GetScan`, `ListScans`, `GetScanReport`) in `safedep.services.malysis.v1`, published at [buf.build/safedep/api](https://buf.build/safedep/api). Direct API integration uses the same authentication model as the CLI. See the [API introduction](/reference/api-introduction).
+The CLI is a thin client over `PackageScanService` (`SubmitScan`, `GetScan`, `ListScans`, `GetScanReport`) in `safedep.services.malysis.v1`, published at [buf.build/safedep/api](https://buf.build/safedep/api). The service is ConnectRPC, so it also speaks plain HTTP/JSON: POST to `https://cloud.safedep.io/safedep.services.malysis.v1.PackageScanService/<Method>`.
+
+Direct API access uses the same authentication model as the CLI: an `authorization` header carrying the access token from your OAuth2 session (an API key does not work), and an `x-tenant-id` header carrying your tenant domain. The CLI does not print its session token today; for most integrations, drive the CLI or use a [generated SDK](https://buf.build/safedep/api/sdks) with your own OAuth2 session.
+
+<Tabs>
+  <Tab title="curl">
+    ```bash
+    # Submit a scan
+    curl https://cloud.safedep.io/safedep.services.malysis.v1.PackageScanService/SubmitScan \
+      -H "authorization: $SAFEDEP_ACCESS_TOKEN" \
+      -H "x-tenant-id: your-company.safedep.io" \
+      --json '{"target":{"package_version":{"package":{"ecosystem":"ECOSYSTEM_NPM","name":"express"},"version":"4.18.2"}}}'
+
+    # Poll the scan by id
+    curl https://cloud.safedep.io/safedep.services.malysis.v1.PackageScanService/GetScan \
+      -H "authorization: $SAFEDEP_ACCESS_TOKEN" \
+      -H "x-tenant-id: your-company.safedep.io" \
+      --json '{"scan_id":"<scan-id>"}'
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```python
+    import requests
+
+    BASE = "https://cloud.safedep.io/safedep.services.malysis.v1.PackageScanService"
+    HEADERS = {
+        "authorization": ACCESS_TOKEN,          # OAuth2 session access token
+        "x-tenant-id": "your-company.safedep.io",
+    }
+
+    submit = requests.post(f"{BASE}/SubmitScan", headers=HEADERS, json={
+        "target": {
+            "package_version": {
+                "package": {"ecosystem": "ECOSYSTEM_NPM", "name": "express"},
+                "version": "4.18.2",
+            }
+        }
+    })
+    submit.raise_for_status()
+    scan_id = submit.json()["scanId"]
+
+    scan = requests.post(f"{BASE}/GetScan", headers=HEADERS, json={"scan_id": scan_id})
+    scan.raise_for_status()
+    print(scan.json())
+    ```
+  </Tab>
+</Tabs>
+
+See the [API introduction](/reference/api-introduction) for transport details and rate limits.
 
 <CardGroup cols={2}>
   <Card title="Usage & On-Demand Billing" icon="coins" href="/governance/cloud/usage-billing">

--- a/package-security/scan/automation.mdx
+++ b/package-security/scan/automation.mdx
@@ -9,11 +9,11 @@ On-demand scanning is built to be driven by automation: platform teams wiring pr
 
 `safedep package scan` calls a control-plane API that authenticates with your signed-in session, established by `safedep auth login`. **API keys do not submit scans.** This is a deliberate design decision, not a missing feature.
 
-The reasoning: every scan draws down your plan's allowance, and with [on-demand billing](/governance/cloud/usage-billing) enabled it can create real charges. SafeDep treats operations that spend your money as control-plane operations, which require the stronger trust of a signed-in session. API keys are data-plane credentials: long-lived, distributed to tools and CI environments, and fine for reading curated threat intel. A leaked API key can read intel; it cannot spend your scan budget.
+The reasoning: every scan draws down your plan's allowance, and with [on-demand billing](/governance/cloud/usage-billing) enabled it can create real charges. SafeDep treats operations that spend your money as control-plane operations, which require the stronger trust of a signed-in session. API keys are data-plane credentials: long-lived, distributed to tools and CI environments, and fine for reading curated threat intel. A leaked API key can read intel, but it cannot spend your scan budget.
 
 What this means in practice:
 
-- **Automation on a workstation works.** Scripts and AI agents running where a human has signed in (a developer machine, an agent sandbox with the CLI configured) submit scans normally. The CLI refreshes the session silently; re-run `safedep auth login` when the refresh eventually expires.
+- **Automation on a workstation works.** Scripts and AI agents running where a human has signed in (a developer machine, an agent sandbox with the CLI configured) submit scans normally. The CLI refreshes the session silently. Re-run `safedep auth login` when the refresh eventually expires.
 - **Headless CI cannot submit scans today.** There is no non-interactive credential for scan submission. If your pipeline needs an inline malicious-package gate, use the free fast-path lookup with [Vet](/governance/cloud/malware-analysis), which works with an API key or no account at all.
 
 ## Machine-readable output
@@ -69,15 +69,15 @@ safedep package scan show --scan-id "$scan_id" -o json   # full report, once com
 
 ## Retries are free
 
-Submitting the same ecosystem, name, and version again returns the existing scan instead of creating a new one. Retrying after a network failure or a CLI timeout is safe and does not draw down your allowance twice. `--rescan` opts out of this and forces a fresh analysis, which counts against the allowance.
+Submitting the same ecosystem, name, and version again returns the existing scan instead of creating a new one. Retrying after a network failure or a CLI timeout is safe and does not draw down your allowance twice. `--rescan` opts out of this and forces a new analysis, which counts against the allowance.
 
-A CLI timeout does not fail the scan. `scan run` waits up to 5 minutes by default (`--timeout` adjusts this); if it times out, the scan keeps running server-side, and the error message includes the `scan get` command to resume polling.
+A CLI timeout does not fail the scan. `scan run` waits up to 5 minutes by default (`--timeout` adjusts this). If it times out, the scan keeps running server-side, and the error message includes the `scan get` command to resume polling.
 
 ## Direct API access
 
 The CLI is a thin client over `PackageScanService` (`SubmitScan`, `GetScan`, `ListScans`, `GetScanReport`) in `safedep.services.malysis.v1`, published at [buf.build/safedep/api](https://buf.build/safedep/api). The service is ConnectRPC, so it also speaks plain HTTP/JSON: POST to `https://cloud.safedep.io/safedep.services.malysis.v1.PackageScanService/<Method>`.
 
-Direct API access uses the same authentication model as the CLI: an `authorization` header carrying the access token from your OAuth2 session (an API key does not work), and an `x-tenant-id` header carrying your tenant domain. The CLI does not print its session token today; for most integrations, drive the CLI or use a [generated SDK](https://buf.build/safedep/api/sdks) with your own OAuth2 session.
+Direct API access uses the same authentication model as the CLI: an `authorization` header carrying the access token from your OAuth2 session (an API key does not work), and an `x-tenant-id` header carrying your tenant domain. The CLI does not print its session token today. For most integrations, drive the CLI or use a [generated SDK](https://buf.build/safedep/api/sdks) with your own OAuth2 session.
 
 <Tabs>
   <Tab title="curl">

--- a/package-security/scan/automation.mdx
+++ b/package-security/scan/automation.mdx
@@ -1,0 +1,87 @@
+---
+title: Scanning from CI and AI Agents
+description: "Use on-demand package scanning from scripts and AI agents: authentication model, JSON output, verdict gating, polling, and retries."
+---
+
+On-demand scanning is built to be driven by automation: platform teams wiring pre-adoption checks into internal tooling, and AI agents checking an external component before using it. This guide covers the contract that automation depends on.
+
+## A signed-in session is required
+
+`safedep package scan` calls a control-plane API that authenticates with your signed-in session, established by `safedep auth login`. **API keys do not submit scans.** This is a deliberate design decision, not a missing feature.
+
+The reasoning: every scan draws down your plan's allowance, and with [on-demand billing](/governance/cloud/usage-billing) enabled it can create real charges. SafeDep treats operations that spend your money as control-plane operations, which require the stronger trust of a signed-in session. API keys are data-plane credentials: long-lived, distributed to tools and CI environments, and fine for reading curated threat intel. A leaked API key can read intel; it cannot spend your scan budget.
+
+What this means in practice:
+
+- **Automation on a workstation works.** Scripts and AI agents running where a human has signed in (a developer machine, an agent sandbox with the CLI configured) submit scans normally. The CLI refreshes the session silently; re-run `safedep auth login` when the refresh eventually expires.
+- **Headless CI cannot submit scans today.** There is no non-interactive credential for scan submission. If your pipeline needs an inline malicious-package gate, use the free fast-path lookup with [Vet](/governance/cloud/malware-analysis), which works with an API key or no account at all.
+
+## Machine-readable output
+
+Every command takes `-o json` (also `-o plain` for tab-separated lines). A scan object looks like:
+
+```json
+{
+  "scan_id": "01J...",
+  "target": {
+    "ecosystem": "npm",
+    "name": "express",
+    "version": "4.18.2"
+  },
+  "status": "completed",
+  "verdict": "benign",
+  "confidence": 0.98,
+  "created_at": "2026-08-07T10:00:00Z",
+  "completed_at": "2026-08-07T10:03:12Z"
+}
+```
+
+`status` ends at `completed` or `failed`. `verdict` is present only once the scan is `completed`, and is one of `malware`, `benign`, or `inconclusive`. On failure, `failure_reason` carries the human-readable cause and `failure_code` a stable classification when one exists (for example `package-not-found`).
+
+## Gate on the verdict, not the exit code
+
+`scan run` exits non-zero when the scan fails or the CLI hits an error (timeout, auth). A scan that completes exits zero **whatever the verdict**: completing the analysis is the command's job. A gate must check the verdict field:
+
+```bash
+verdict=$(safedep package scan run "pkg:npm/express@4.18.2" -o json | jq -r .verdict)
+
+case "$verdict" in
+  benign) echo "ok" ;;
+  malware) echo "blocked: malware verdict"; exit 1 ;;
+  *) echo "needs review: verdict=$verdict"; exit 1 ;;
+esac
+```
+
+Treat `inconclusive` as needs-review, not as a pass. The analysis completed but could not reach a confident verdict.
+
+## Submit now, check later
+
+For long-running pipelines or agents that should not block, submit without waiting and poll:
+
+```bash
+scan_id=$(safedep package scan run "pkg:npm/express@4.18.2" --wait=false -o json | jq -r .scan_id)
+
+safedep package scan get --scan-id "$scan_id" -o json
+safedep package scan show --scan-id "$scan_id" -o json   # full report, once completed
+```
+
+`get` returns the current status and, once completed, the verdict. `show` returns the full report and errors while the scan is still running.
+
+## Retries are free
+
+Submitting the same ecosystem, name, and version again returns the existing scan instead of creating a new one. Retrying after a network failure or a CLI timeout is safe and does not draw down your allowance twice. `--rescan` opts out of this and forces a fresh analysis, which counts against the allowance.
+
+A CLI timeout does not fail the scan. `scan run` waits up to 5 minutes by default (`--timeout` adjusts this); if it times out, the scan keeps running server-side, and the error message includes the `scan get` command to resume polling.
+
+## Direct API access
+
+The CLI is a thin client over `PackageScanService` (`SubmitScan`, `GetScan`, `ListScans`, `GetScanReport`) in `safedep.services.malysis.v1`, published at [buf.build/safedep/api](https://buf.build/safedep/api). Direct API integration uses the same authentication model as the CLI. See the [API introduction](/reference/api-introduction).
+
+<CardGroup cols={2}>
+  <Card title="Usage & On-Demand Billing" icon="coins" href="/governance/cloud/usage-billing">
+    Allowances, spending caps, and the commands to inspect usage.
+  </Card>
+  <Card title="Package Scan Quickstart" icon="rocket" href="/package-security/scan/quickstart">
+    First-time setup and your first scan.
+  </Card>
+</CardGroup>

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -9,17 +9,18 @@ It is an independent SafeDep Cloud feature, used from the `safedep` CLI or the S
 
 ## Fast path and slow path
 
-SafeDep answers "is this component malicious?" in two distinct ways. Knowing which one you need saves time and money.
+SafeDep answers "is this component malicious?" through two paths built on the same scanning infrastructure.
+
+The **fast path** is automatic. SafeDep continuously scans packages from public registries and records verdicts in its known malicious packages database. SafeDep tools query that database to protect the SDLC at each stage: [PMG](/package-security/pmg/overview) at install time, [Vet](/governance/vet/overview) in CI, the [SafeDep MCP server](/ai-security/mcp-server) in AI agent sessions. It is free, answers in milliseconds, and needs no action from you.
+
+The **slow path** is on-demand scanning: the same scanning infrastructure, made available to you on demand. Use it where continuous scanning does not reach. That means components that are not registry packages, such as an MCP server or AI agent skill adopted from a GitHub repository, or an IDE extension, and packages that are not covered by SafeDep's continuous scanning.
 
 |  | Fast path: known-malicious lookup | Slow path: on-demand scan |
 |---|---|---|
 | What it checks | SafeDep's database of already-analyzed, known malicious packages | The exact component you name, analyzed on demand |
 | Answers in | Milliseconds | Minutes |
 | Cost | Free | Metered, from your plan's scan allowance |
-| Built into | [Vet](/governance/vet/overview), [PMG](/package-security/pmg/overview), the [SafeDep MCP server](/ai-security/mcp-server) | The `safedep` CLI and the SafeDep API |
-| Best for | Inline gates: package installs, CI checks, agent tool calls | Pre-adoption review of a specific version, components not in the database, non-registry components |
-
-Use the fast path everywhere it fits: it is free and instant. Reach for an on-demand scan when the component is not in the database yet, when you need a verdict for the exact version you are about to adopt, or when the component is not an OSS registry package at all.
+| Used through | [Vet](/governance/vet/overview), [PMG](/package-security/pmg/overview), the [SafeDep MCP server](/ai-security/mcp-server), automatically | The `safedep` CLI and the SafeDep API, when you ask |
 
 ## How a scan works
 

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -27,7 +27,11 @@ The **slow path** is on-demand scanning: the same scanning infrastructure, made 
 Every scan runs SafeDep's malware analysis pipeline against the exact component you name:
 
 - **Static analysis** examines the component's code and metadata for malicious behavior signals: install-time hooks, obfuscation, network and filesystem access, credential theft patterns, and more.
-- **AI agent triage** investigates those signals. Static analysis alone flags suspicious-looking code in many legitimate packages, so an AI agent examines each signal in context to separate real threats from benign code. The agent draws on SafeDep's code context for open source software: baselines and memories built from continuously analyzing packages across ecosystems. Because SafeDep knows what normal looks like for OSS code, triage rejects false alarms that a signature-only scanner would surface and digs into behavior that is genuinely out of place.
+- **AI agent triage** investigates those signals. Static analysis alone flags suspicious-looking code in many legitimate packages, so an AI agent examines each signal in context to separate real threats from benign code.
+
+<Tip>
+Triage works because the agent draws on SafeDep's code context for open source software: baselines and memories built from continuously analyzing packages across ecosystems. Because SafeDep knows what normal looks like for OSS code, triage rejects false alarms that a signature-only scanner would surface and digs into behavior that is genuinely out of place.
+</Tip>
 
 The result is a verdict backed by evidence you can inspect, not a bare score. See [What a scan produces](#what-a-scan-produces).
 

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: On-Demand Package Scanning
-description: "Run a fresh malware analysis of any package, IDE extension, or GitHub repository before you use it."
+description: "Run an on-demand malware analysis of any package, IDE extension, or GitHub repository before you use it."
 ---
 
-On-demand package scanning submits a software component to SafeDep Cloud for a fresh malware analysis and returns a verdict with evidence. You name an exact version of a package, an IDE extension, or a GitHub repository; SafeDep analyzes it and tells you whether it is safe to use.
+On-demand package scanning submits a software component to SafeDep Cloud for malware analysis and returns a verdict with evidence. You name an exact version of a package, an IDE extension, or a GitHub repository. SafeDep analyzes it and tells you whether it is safe to use.
 
 It is an independent SafeDep Cloud feature, used from the `safedep` CLI or the SafeDep API. It is not coupled to Vet or PMG.
 
@@ -13,7 +13,7 @@ SafeDep answers "is this component malicious?" in two distinct ways. Knowing whi
 
 |  | Fast path: known-malicious lookup | Slow path: on-demand scan |
 |---|---|---|
-| What it checks | SafeDep's database of already-analyzed, known malicious packages | The exact component you name, analyzed fresh |
+| What it checks | SafeDep's database of already-analyzed, known malicious packages | The exact component you name, analyzed on demand |
 | Answers in | Milliseconds | Minutes |
 | Cost | Free | Metered, from your plan's scan allowance |
 | Built into | [Vet](/governance/vet/overview), [PMG](/package-security/pmg/overview), the [SafeDep MCP server](/ai-security/mcp-server) | The `safedep` CLI and the SafeDep API |

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -1,0 +1,90 @@
+---
+title: On-Demand Package Scanning
+description: "Run a fresh malware analysis of any package, IDE extension, or GitHub repository before you use it."
+---
+
+On-demand package scanning submits a software component to SafeDep Cloud for a fresh malware analysis and returns a verdict with evidence. You name an exact version of a package, an IDE extension, or a GitHub repository; SafeDep analyzes it and tells you whether it is safe to use.
+
+It is an independent SafeDep Cloud feature, used from the `safedep` CLI or the SafeDep API. It is not coupled to Vet or PMG.
+
+## Fast path and slow path
+
+SafeDep answers "is this component malicious?" in two distinct ways. Knowing which one you need saves time and money.
+
+|  | Fast path: known-malicious lookup | Slow path: on-demand scan |
+|---|---|---|
+| What it checks | SafeDep's database of already-analyzed, known malicious packages | The exact component you name, analyzed fresh |
+| Answers in | Milliseconds | Minutes |
+| Cost | Free | Metered, from your plan's scan allowance |
+| Built into | [Vet](/governance/vet/overview), [PMG](/package-security/pmg/overview), the [SafeDep MCP server](/ai-security/mcp-server) | The `safedep` CLI and the SafeDep API |
+| Best for | Inline gates: package installs, CI checks, agent tool calls | Pre-adoption review of a specific version, components not in the database, non-registry components |
+
+Use the fast path everywhere it fits: it is free and instant. Reach for an on-demand scan when the component is not in the database yet, when you need a verdict for the exact version you are about to adopt, or when the component is not an OSS registry package at all.
+
+## What you can scan
+
+<CardGroup cols={3}>
+  <Card title="npm" icon="node-js">
+    JavaScript and TypeScript packages
+  </Card>
+  <Card title="PyPI" icon="python">
+    Python packages
+  </Card>
+  <Card title="Go Modules" icon="golang">
+    Go modules
+  </Card>
+  <Card title="RubyGems" icon="gem">
+    Ruby gems
+  </Card>
+  <Card title="Cargo" icon="rust">
+    Rust crates
+  </Card>
+  <Card title="VS Code Extensions" icon="puzzle-piece">
+    Visual Studio Code extensions
+  </Card>
+  <Card title="Open VSX Extensions" icon="puzzle-piece">
+    Extensions from the Open VSX registry
+  </Card>
+  <Card title="GitHub Actions" icon="github">
+    Actions used in your workflows
+  </Card>
+  <Card title="GitHub Repositories" icon="code-branch">
+    Any repository, at a tag, branch, or commit
+  </Card>
+</CardGroup>
+
+A GitHub repository target covers anything distributed as a repository rather than through a package registry: a library you found on GitHub, an AI agent skill, a project template. This makes on-demand scanning usable as a pre-use check for components that no registry-based tool can see.
+
+## What a scan produces
+
+A completed scan carries a verdict: `malware`, `benign`, or `inconclusive`, with a confidence score. When the verdict is `malware`, the full report explains why: a summary, file-level evidence (file, line, observed behavior), project-level evidence, indicators of compromise, and warnings.
+
+A scan that cannot run, for example because the named version does not exist in the registry, ends as `failed` with a reason. Failure is an operational outcome, not a verdict.
+
+For how SafeDep decides what is malicious, see [Malicious Package](/concepts/malicious-package).
+
+## Availability
+
+<Note>
+On-demand package scanning requires a SafeDep Cloud **Professional** or **Enterprise** plan. Paid plans include a monthly scan allowance per seat, pooled across your tenant. Beyond the allowance, you can opt in to [usage-based on-demand billing](/governance/cloud/usage-billing). The free 30-day trial includes one seat's allowance. See [pricing](https://safedep.io/pricing).
+</Note>
+
+Current limits, stated plainly:
+
+- Scanning is available from the CLI and the API. There is no web dashboard for on-demand scans yet.
+- Submitting a scan requires a signed-in session. API keys do not submit scans. See [Scanning from CI and AI Agents](/package-security/scan/automation) for the reasoning.
+- A scan typically completes in a few minutes. The CLI waits up to 5 minutes by default.
+
+## Get started
+
+<CardGroup cols={1}>
+  <Card title="Package Scan Quickstart" icon="rocket" href="/package-security/scan/quickstart">
+    Install the CLI, sign in, and run your first scan.
+  </Card>
+  <Card title="Scanning from CI and AI Agents" icon="robot" href="/package-security/scan/automation">
+    Authentication model, JSON output, verdict gating, polling, and retry semantics for automation.
+  </Card>
+  <Card title="Usage & On-Demand Billing" icon="coins" href="/governance/cloud/usage-billing">
+    How allowances are counted and how to enable usage-based billing beyond them.
+  </Card>
+</CardGroup>

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -21,6 +21,15 @@ SafeDep answers "is this component malicious?" in two distinct ways. Knowing whi
 
 Use the fast path everywhere it fits: it is free and instant. Reach for an on-demand scan when the component is not in the database yet, when you need a verdict for the exact version you are about to adopt, or when the component is not an OSS registry package at all.
 
+## How a scan works
+
+Every scan runs SafeDep's malware analysis pipeline against the exact component you name:
+
+- **Static analysis** examines the component's code and metadata for malicious behavior signals: install-time hooks, obfuscation, network and filesystem access, credential theft patterns, and more.
+- **AI agent triage** investigates those signals. Static analysis alone flags suspicious-looking code in many legitimate packages, so an AI agent examines each signal in context to separate real threats from benign code. The agent draws on SafeDep's code context for open source software: baselines and memories built from continuously analyzing packages across ecosystems. Because SafeDep knows what normal looks like for OSS code, triage rejects false alarms that a signature-only scanner would surface and digs into behavior that is genuinely out of place.
+
+The result is a verdict backed by evidence you can inspect, not a bare score. See [What a scan produces](#what-a-scan-produces).
+
 ## What you can scan
 
 <CardGroup cols={3}>

--- a/package-security/scan/overview.mdx
+++ b/package-security/scan/overview.mdx
@@ -66,7 +66,7 @@ For how SafeDep decides what is malicious, see [Malicious Package](/concepts/mal
 ## Availability
 
 <Note>
-On-demand package scanning requires a SafeDep Cloud **Professional** or **Enterprise** plan. Paid plans include a monthly scan allowance per seat, pooled across your tenant. Beyond the allowance, you can opt in to [usage-based on-demand billing](/governance/cloud/usage-billing). The free 30-day trial includes one seat's allowance. See [pricing](https://safedep.io/pricing).
+On-demand package scanning requires a SafeDep Cloud **Professional** or **Enterprise** plan. Paid plans include a monthly scan allowance per seat, pooled across your tenant. Beyond the allowance, you can opt in to [usage-based on-demand billing](/governance/cloud/usage-billing). The free trial includes one seat's allowance. See [pricing](https://safedep.io/pricing).
 </Note>
 
 Current limits, stated plainly:

--- a/package-security/scan/quickstart.mdx
+++ b/package-security/scan/quickstart.mdx
@@ -1,0 +1,107 @@
+---
+title: Package Scan Quickstart
+description: "Install the safedep CLI, sign in to SafeDep Cloud, and run your first on-demand package scan."
+---
+
+In this guide you install the `safedep` CLI, sign in to SafeDep Cloud, activate a plan, and scan your first package. Setup takes a few minutes; each scan takes a few minutes more.
+
+For what on-demand scanning is and when to use it, see the [overview](/package-security/scan/overview).
+
+<Steps>
+  <Step title="Install the safedep CLI">
+    <Tabs>
+      <Tab title="Homebrew">
+        ```bash
+        brew install --cask safedep/tap/cli
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm install -g @safedep/cli
+        ```
+      </Tab>
+    </Tabs>
+
+    Verify with `safedep version`.
+  </Step>
+
+  <Step title="Sign in to SafeDep Cloud">
+    ```bash
+    safedep auth login
+    ```
+
+    This opens a browser-based device login. If you are new to SafeDep, it also sets up your account. The CLI keeps your session refreshed after this one sign-in.
+  </Step>
+
+  <Step title="Check your plan">
+    ```bash
+    safedep subscription status
+    ```
+
+    On-demand scanning needs a Professional or Enterprise plan. If you do not have one yet, activate the free 30-day trial:
+
+    ```bash
+    safedep subscription trial enable
+    ```
+
+    The command asks for basic billing profile details the first time. No payment method is needed for the trial. The trial includes one seat's monthly scan allowance.
+  </Step>
+
+  <Step title="Scan a package">
+    ```bash
+    safedep package scan run pkg:npm/express@4.18.2
+    ```
+
+    The CLI submits the scan and waits, showing status as the analysis progresses. When the scan completes you get a verdict panel: `benign`, `malware`, or `inconclusive`, with a confidence score. On a `malware` verdict the full evidence report is printed inline.
+
+    The target can be a purl (as above), a GitHub URL, or an explicit triple:
+
+    ```bash
+    safedep package scan run --ecosystem pypi --name requests --version 2.32.3
+    ```
+  </Step>
+
+  <Step title="Scan something that is not a registry package">
+    On-demand scanning also covers components no registry-based tool can check. Scan a GitHub repository at a tag, branch, or commit:
+
+    ```bash
+    safedep package scan run https://github.com/safedep/vet/tree/v1.18.1
+    ```
+
+    Or a VS Code extension:
+
+    ```bash
+    safedep package scan run --ecosystem vscode --name <publisher.extension> --version <version>
+    ```
+  </Step>
+
+  <Step title="Review your scans">
+    List the tenant's scans, newest first:
+
+    ```bash
+    safedep package scan list
+    ```
+
+    Fetch the full report of a completed scan, by package or by scan id:
+
+    ```bash
+    safedep package scan show pkg:npm/express@4.18.2
+    safedep package scan show --scan-id <scan-id> --save report.json
+    ```
+  </Step>
+</Steps>
+
+<Info>
+Re-running `scan run` for the same package version returns the existing scan instead of starting (and counting) a new one. Use `--rescan` to force a fresh analysis.
+</Info>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scanning from CI and AI Agents" icon="robot" href="/package-security/scan/automation">
+    JSON output, verdict gating, polling, and the authentication model for automation.
+  </Card>
+  <Card title="Usage & On-Demand Billing" icon="coins" href="/governance/cloud/usage-billing">
+    Check your scan allowance and enable usage-based billing beyond it.
+  </Card>
+</CardGroup>

--- a/package-security/scan/quickstart.mdx
+++ b/package-security/scan/quickstart.mdx
@@ -38,7 +38,7 @@ For what on-demand scanning is and when to use it, see the [overview](/package-s
     safedep subscription status
     ```
 
-    On-demand scanning needs a Professional or Enterprise plan. If you do not have one yet, activate the free 30-day trial:
+    On-demand scanning needs a Professional or Enterprise plan. If you do not have one yet, activate the free trial:
 
     ```bash
     safedep subscription trial enable
@@ -68,10 +68,10 @@ For what on-demand scanning is and when to use it, see the [overview](/package-s
     safedep package scan run https://github.com/safedep/vet/tree/v1.18.1
     ```
 
-    Or a VS Code extension:
+    Or a VS Code extension, named as `publisher.extension`:
 
     ```bash
-    safedep package scan run --ecosystem vscode --name <publisher.extension> --version <version>
+    safedep package scan run --ecosystem vscode --name esbenp.prettier-vscode --version 9.9.0
     ```
   </Step>
 

--- a/package-security/scan/quickstart.mdx
+++ b/package-security/scan/quickstart.mdx
@@ -3,7 +3,7 @@ title: Package Scan Quickstart
 description: "Install the safedep CLI, sign in to SafeDep Cloud, and run your first on-demand package scan."
 ---
 
-In this guide you install the `safedep` CLI, sign in to SafeDep Cloud, activate a plan, and scan your first package. Setup takes a few minutes; each scan takes a few minutes more.
+In this guide you install the `safedep` CLI, sign in to SafeDep Cloud, activate a plan, and scan your first package. Setup takes a few minutes. Each scan takes a few minutes more.
 
 For what on-demand scanning is and when to use it, see the [overview](/package-security/scan/overview).
 
@@ -92,7 +92,7 @@ For what on-demand scanning is and when to use it, see the [overview](/package-s
 </Steps>
 
 <Info>
-Re-running `scan run` for the same package version returns the existing scan instead of starting (and counting) a new one. Use `--rescan` to force a fresh analysis.
+Re-running `scan run` for the same package version returns the existing scan instead of starting (and counting) a new one. Use `--rescan` to force a new analysis.
 </Info>
 
 ## Next steps


### PR DESCRIPTION
Adds user-facing documentation for on-demand package scanning (`safedep package scan`), positioned as an independent SafeDep Cloud feature that is not coupled to Vet or PMG.

## New pages

- **`package-security/scan/overview`** (group landing): fast path vs slow path framing (free known-malicious lookup vs metered fresh analysis), supported targets including IDE extensions and GitHub repositories, verdict model (`malware` / `benign` / `inconclusive`), availability, and current limits stated plainly.
- **`package-security/scan/quickstart`**: install the CLI, sign in, activate the 30-day trial, scan a purl, a GitHub repository at a tag, and a VS Code extension, then review results.
- **`package-security/scan/automation`**: the automation contract. Explains why API keys intentionally do not submit scans (scans spend money, so submission is a control-plane operation requiring a signed-in session), JSON output schema, gating on the verdict rather than the exit code, submit-now-check-later polling, idempotent retries, and `--rescan` semantics.
- **`governance/cloud/usage-billing`**: pooled per-seat allowances, `subscription ondemand status/enable/disable`, the monthly spending cap, terms acceptance, and the billing portal. Prices stay on the pricing page.

## Updated pages

- `governance/cloud/malware-analysis`: replaces the "on-demand analysis has been retired" note with the fast/slow path reframe and cross-links the new feature.
- `get-started/cli-tools` and `package-security/overview`: cards and copy updates surfacing on-demand scanning.
- `docs.json`: new "On-Demand Package Scanning" group in the Package Security tab; `usage-billing` added to the SafeDep Cloud group.
- `docs-ia.md` (§1, §3, §7) and the condensed `CLAUDE.md` copy: synced with `docs.json`, including three previously unmapped pages (`pmg/github-actions`, `vet/ai-bom`, `cloud/talk-to-safedep`); page total corrected to 67.

## Verification

- Commands, flags, targets, verdicts, and billing behavior verified against `safedep/cli`, `safedep/control-tower`, and `safedep/dry` source.
- `mintlify broken-links` passes with only the three known pre-existing `essentials/` failures.
- No em-dashes in touched pages; the quickstart's repository example uses vet's real `v1.18.1` tag.

Note for reviewers: the Notion mirror of `docs-ia.md` still needs a manual sync per §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGMXtxFgN4SD36uFaSyFw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGMXtxFgN4SD36uFaSyFw2)_