### PR TITLE
Add agentic endpoint investigation guide and SafeDep skill install page

### DIFF
--- a/docs-ia.md
+++ b/docs-ia.md
@@ -129,7 +129,7 @@ Don't mix Diátaxis types within a single page.
 *Human-readable mirror of `docs.json`. Source of truth is `docs.json`.* Re-synced after the Phase 2 path migration, the Phase 3 sidebar restructure, and the net-new pages landed. A group's clickable landing (Mintlify `root`) is marked *(landing)*.
 
 **Get Started**
-- Introduction: `introduction`, `get-started/cli-tools`
+- Introduction: `introduction`, `get-started/cli-tools`, `get-started/safedep-skill`
 - Core Concepts: `concepts/malicious-package`, `concepts/vulnerability`, `concepts/policy`, `concepts/cel`, `concepts/sbom`, `concepts/tenant`, `concepts/endpoint`
 
 **Package Security** *(tab landing: `package-security/overview`)*
@@ -146,7 +146,7 @@ Don't mix Diátaxis types within a single page.
 - AI Visibility: `governance/ai-governance` *(landing)*, `governance/shadow-ai-detection`, `governance/vet/ai-bom`
 - CI/CD & Platform Integrations: `governance/integrations/overview` *(landing)*, `governance/integrations/github`, `governance/integrations/github-code-scanning`, `governance/integrations/gitlab`, `governance/integrations/bitbucket`, `governance/integrations/defectdojo`, `governance/terraform-audit`
 - SafeDep Cloud: `governance/cloud/overview` *(landing)*, `governance/cloud/quickstart`, `governance/cloud/authentication`, `governance/cloud/usage-billing`, `governance/cloud/sync`, `governance/cloud/talk-to-safedep`, `governance/cloud/alerts`
-  - Endpoint Hub: `governance/cloud/endpoint-hub/overview` *(landing)*, `governance/cloud/endpoint-hub/inventory`, `governance/cloud/endpoint-hub/inventory-catalog`, `governance/cloud/endpoint-hub/package-guard`, `governance/cloud/endpoint-hub/mcp-advisor`
+  - Endpoint Hub: `governance/cloud/endpoint-hub/overview` *(landing)*, `governance/cloud/endpoint-hub/inventory`, `governance/cloud/endpoint-hub/inventory-catalog`, `governance/cloud/endpoint-hub/package-guard`, `governance/cloud/endpoint-hub/mcp-advisor`, `governance/cloud/endpoint-hub/agentic-investigation`
   - Policy & Risk: `governance/cloud/malware-analysis`, `governance/cloud/package-exclusions`
 
 **Reference**
@@ -157,7 +157,7 @@ Don't mix Diátaxis types within a single page.
 - Community: `community`
 - Support: `faq`, `governance/cloud/faq`
 
-Total: **67 pages**
+Total: **69 pages**
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -22,7 +22,8 @@
             "icon": "book-open",
             "pages": [
               "introduction",
-              "get-started/cli-tools"
+              "get-started/cli-tools",
+              "get-started/safedep-skill"
             ]
           },
           {
@@ -150,7 +151,8 @@
                   "governance/cloud/endpoint-hub/inventory",
                   "governance/cloud/endpoint-hub/inventory-catalog",
                   "governance/cloud/endpoint-hub/package-guard",
-                  "governance/cloud/endpoint-hub/mcp-advisor"
+                  "governance/cloud/endpoint-hub/mcp-advisor",
+                  "governance/cloud/endpoint-hub/agentic-investigation"
                 ]
               },
               {

--- a/get-started/safedep-skill.mdx
+++ b/get-started/safedep-skill.mdx
@@ -3,9 +3,7 @@ title: "Install the SafeDep Skill"
 description: "Add the SafeDep Agent Skill to Claude Code or any skills-capable AI coding agent."
 ---
 
-The [SafeDep skill](https://github.com/safedep/skills) makes your AI coding agent fluent in SafeDep. With the skill installed, the agent answers SafeDep questions from the official docs instead of memory, picks the right tool for the job, and runs [SafeDep Cloud SQL](/reference/sql-query) queries through the `safedep` CLI.
-
-The skill carries no product knowledge of its own. It routes the agent to these docs, which are published in agent-readable form (`llms.txt` and Markdown endpoints). Update the skill rarely; the knowledge stays current because the docs do.
+The [SafeDep skill](https://github.com/safedep/skills) makes your AI coding agent fluent in SafeDep. With the skill installed, the agent answers SafeDep questions from the official sources instead of memory, picks the right SafeDep tool for the task, and helps you install, configure, and use it. Answers stay current because the agent reads the live documentation, not its training data.
 
 ## Install
 
@@ -51,16 +49,15 @@ What does SafeDep PMG do?
 
 The agent should load the skill, fetch the answer from docs.safedep.io, and cite the page it used.
 
-## Sign in for cloud queries
+## Set up the safedep CLI
 
-The skill answers product questions without an account. Questions about *your* data, such as "what did PMG block this week", need the `safedep` CLI signed in to your [SafeDep Cloud tenant](/governance/cloud/quickstart):
+The skill answers product questions without an account. Questions about *your* data, such as "what did PMG block this week", run through the [safedep CLI](https://github.com/safedep/cli) against your [SafeDep Cloud tenant](/governance/cloud/quickstart). The skill tells the agent to check for the CLI and your sign-in state, and to hand a step back to you when it needs a human:
 
-```bash
-safedep auth login
-safedep auth status
-```
+1. Install the CLI. Follow the [CLI repository](https://github.com/safedep/cli#install) instructions.
+2. Sign in with `safedep auth login`. Sign-in opens a browser, so the agent asks you to run it.
+3. Confirm the tenant with `safedep auth status`.
 
-Sign-in opens a browser, so the agent asks you to run it. See [Authentication](/governance/cloud/authentication).
+See [Authentication](/governance/cloud/authentication).
 
 <CardGroup cols={2}>
   <Card title="Talk to SafeDep" icon="comments" href="/governance/cloud/talk-to-safedep">

--- a/get-started/safedep-skill.mdx
+++ b/get-started/safedep-skill.mdx
@@ -53,16 +53,33 @@ The agent should load the skill, fetch the answer from docs.safedep.io, and cite
 
 The skill answers product questions without an account. Questions about *your* data, such as "what did PMG block this week", run through the [safedep CLI](https://github.com/safedep/cli) against your [SafeDep Cloud tenant](/governance/cloud/quickstart). The skill tells the agent to check for the CLI and your sign-in state, and to hand a step back to you when it needs a human:
 
-1. Install the CLI with Homebrew or npm. The [CLI repository](https://github.com/safedep/cli#install) lists more options.
+<Steps>
+  <Step title="Install the CLI">
+    The [CLI repository](https://github.com/safedep/cli#install) lists more options.
 
-   ```bash
-   brew install safedep/tap/cli
-   # or
-   npm install -g @safedep/cli
-   ```
+    <CodeGroup>
+    ```bash Homebrew
+    brew install safedep/tap/cli
+    ```
 
-2. Sign in with `safedep auth login`. Sign-in opens a browser, so the agent asks you to run it.
-3. Confirm the tenant with `safedep auth status`.
+    ```bash npm
+    npm install -g @safedep/cli
+    ```
+    </CodeGroup>
+  </Step>
+  <Step title="Sign in">
+    Sign-in opens a browser, so the agent asks you to run it.
+
+    ```bash
+    safedep auth login
+    ```
+  </Step>
+  <Step title="Confirm the tenant">
+    ```bash
+    safedep auth status
+    ```
+  </Step>
+</Steps>
 
 See [Authentication](/governance/cloud/authentication).
 

--- a/get-started/safedep-skill.mdx
+++ b/get-started/safedep-skill.mdx
@@ -1,0 +1,72 @@
+---
+title: "Install the SafeDep Skill"
+description: "Add the SafeDep Agent Skill to Claude Code or any skills-capable AI coding agent."
+---
+
+The [SafeDep skill](https://github.com/safedep/skills) makes your AI coding agent fluent in SafeDep. With the skill installed, the agent answers SafeDep questions from the official docs instead of memory, picks the right tool for the job, and runs [SafeDep Cloud SQL](/reference/sql-query) queries through the `safedep` CLI.
+
+The skill carries no product knowledge of its own. It routes the agent to these docs, which are published in agent-readable form (`llms.txt` and Markdown endpoints). Update the skill rarely; the knowledge stays current because the docs do.
+
+## Install
+
+<Tabs>
+  <Tab title="Claude Code">
+    Add the marketplace, then install the plugin:
+
+    ```bash
+    /plugin marketplace add safedep/skills
+    /plugin install safedep-agent-skills@safedep-agent-skills
+    ```
+
+    Turn on auto-update in Claude Code settings to stay on the current version.
+  </Tab>
+  <Tab title="Any agent">
+    Works with any agent that supports Agent Skills:
+
+    ```bash
+    npx skills add safedep/skills
+    ```
+
+    Run `npx skills update` to refresh it later.
+  </Tab>
+  <Tab title="Cursor">
+    Copy the skill into your project:
+
+    ```bash
+    git clone https://github.com/safedep/skills.git
+    cp -r skills/skills/safedep .cursor/skills/
+    ```
+
+    Cursor discovers skills from `.cursor/skills/` on startup.
+  </Tab>
+</Tabs>
+
+## Verify
+
+Ask your agent a SafeDep question:
+
+```text
+What does SafeDep PMG do?
+```
+
+The agent should load the skill, fetch the answer from docs.safedep.io, and cite the page it used.
+
+## Sign in for cloud queries
+
+The skill answers product questions without an account. Questions about *your* data, such as "what did PMG block this week", need the `safedep` CLI signed in to your [SafeDep Cloud tenant](/governance/cloud/quickstart):
+
+```bash
+safedep auth login
+safedep auth status
+```
+
+Sign-in opens a browser, so the agent asks you to run it. See [Authentication](/governance/cloud/authentication).
+
+<CardGroup cols={2}>
+  <Card title="Talk to SafeDep" icon="comments" href="/governance/cloud/talk-to-safedep">
+    Ask your supply chain questions in plain English.
+  </Card>
+  <Card title="Agentic Endpoint Investigation" icon="magnifying-glass" href="/governance/cloud/endpoint-hub/agentic-investigation">
+    Investigate package activity across your endpoints with an agent.
+  </Card>
+</CardGroup>

--- a/get-started/safedep-skill.mdx
+++ b/get-started/safedep-skill.mdx
@@ -53,7 +53,14 @@ The agent should load the skill, fetch the answer from docs.safedep.io, and cite
 
 The skill answers product questions without an account. Questions about *your* data, such as "what did PMG block this week", run through the [safedep CLI](https://github.com/safedep/cli) against your [SafeDep Cloud tenant](/governance/cloud/quickstart). The skill tells the agent to check for the CLI and your sign-in state, and to hand a step back to you when it needs a human:
 
-1. Install the CLI. Follow the [CLI repository](https://github.com/safedep/cli#install) instructions.
+1. Install the CLI with Homebrew or npm. The [CLI repository](https://github.com/safedep/cli#install) lists more options.
+
+   ```bash
+   brew install safedep/tap/cli
+   # or
+   npm install -g @safedep/cli
+   ```
+
 2. Sign in with `safedep auth login`. Sign-in opens a browser, so the agent asks you to run it.
 3. Confirm the tenant with `safedep auth status`.
 

--- a/governance/cloud/endpoint-hub/agentic-investigation.mdx
+++ b/governance/cloud/endpoint-hub/agentic-investigation.mdx
@@ -25,7 +25,7 @@ The agent works in a loop:
 2. It writes a query and runs it with `safedep query exec`.
 3. If the server rejects the query, the error says why. The agent corrects the query and retries.
 
-Every query is scoped to your authenticated tenant. The agent reads data; it cannot change it. Each answer traces back to a real query, so you can ask the agent to show the SQL it ran.
+Every query is scoped to your authenticated tenant. The agent reads data; it cannot change it. Each answer traces back to a real query, so you can ask the agent to show the SQL it ran. The query language has no relative dates, so for questions like "in the last 30 days" the agent computes the cutoff timestamp from today's date. The example queries below show literal timestamps for the same reason.
 
 For the query language, the full table list, and the query rules, see [SafeDep Cloud SQL](/reference/sql-query).
 
@@ -61,16 +61,20 @@ Each row is one decision on one endpoint. `PMG_PACKAGE_ACTION_BLOCKED` means PMG
 What did PMG block across our endpoints this month? Group it by endpoint.
 ```
 
-The agent filters `package_guard_events` on the blocked actions and joins to `endpoints`:
+The agent filters `package_guard_events` on both block actions, bounds the time range to the month, and joins to `endpoints`:
 
 ```sql
 SELECT endpoints.identifier, package_guard_events.package_name,
-       package_guard_events.package_ecosystem, package_guard_events.timestamp
+       package_guard_events.package_ecosystem, package_guard_events.package_action,
+       package_guard_events.timestamp
 FROM package_guard_events
 JOIN endpoints ON endpoints.id = package_guard_events.invocation_id
-WHERE package_guard_events.package_action = 'PMG_PACKAGE_ACTION_BLOCKED'
+WHERE package_guard_events.package_action IN ('PMG_PACKAGE_ACTION_BLOCKED', 'PMG_PACKAGE_ACTION_COOLDOWN_BLOCKED')
+  AND package_guard_events.timestamp >= '2026-08-01T00:00:00Z'
 ORDER BY package_guard_events.timestamp DESC
 ```
+
+`PMG_PACKAGE_ACTION_BLOCKED` is a block on a known malicious package. `PMG_PACKAGE_ACTION_COOLDOWN_BLOCKED` is a block on a package too new to trust under the cooldown policy. Both stopped an install.
 
 A block on one endpoint is often the first visible event of a campaign. Follow up with the exposure playbook above for the same package across the fleet.
 
@@ -89,6 +93,7 @@ SELECT endpoints.identifier, package_guard_events.package_name,
 FROM package_guard_events
 JOIN endpoints ON endpoints.id = package_guard_events.invocation_id
 WHERE package_guard_events.event_type = 'PMG_EVENT_TYPE_INSECURE_BYPASS'
+  AND package_guard_events.timestamp >= '2026-07-27T00:00:00Z'
 ORDER BY package_guard_events.timestamp DESC
 ```
 
@@ -109,7 +114,7 @@ WHERE endpoints.last_sync_at < '2026-07-11T00:00:00Z'
 ORDER BY endpoints.last_sync_at ASC
 ```
 
-The query language has no relative dates, so the agent computes the cutoff timestamp from today's date.
+An endpoint can stop reporting for good reasons, such as a decommissioned laptop. Confirm before you treat it as an incident.
 
 ### Get a current verdict on a suspect package
 

--- a/governance/cloud/endpoint-hub/agentic-investigation.mdx
+++ b/governance/cloud/endpoint-hub/agentic-investigation.mdx
@@ -1,0 +1,176 @@
+---
+title: "Agentic Endpoint Investigation"
+description: "Investigate package activity and AI tooling across your developer endpoints with an AI coding agent and the safedep CLI."
+---
+
+Your endpoints report their activity to [Endpoint Hub](/governance/cloud/endpoint-hub/overview): every package install [PMG](/package-security/pmg/overview) allowed or blocked, and the AI tooling `vet` discovered. When something needs investigation, you do not write queries yourself. You ask your AI coding agent. The agent turns your question into a tenant-scoped [SafeDep Cloud SQL](/reference/sql-query) query, runs it with the `safedep` CLI, and reports what it found.
+
+This guide gives you investigation playbooks: the question to ask, what the agent runs, and how to verify the answer.
+
+## Before you start
+
+- Endpoints that sync data to your tenant. Set up [Package Guard sync](/governance/cloud/endpoint-hub/package-guard) for package events, and optionally [Inventory](/governance/cloud/endpoint-hub/inventory) for AI tooling.
+- The `safedep` CLI, signed in with `safedep auth login`. See [Authentication](/governance/cloud/authentication).
+- An AI coding agent with the [SafeDep skill](/get-started/safedep-skill) installed.
+
+<Note>
+The agent cannot sign in for you. Sign-in opens a browser and needs a human. If the agent reports an authentication error, run `safedep auth login` yourself, confirm with `safedep auth status`, and tell the agent to continue.
+</Note>
+
+## How the agent investigates
+
+The agent works in a loop:
+
+1. It discovers the queryable tables with `safedep query schema get`. The schema describes the tables, their columns, the allowed joins, and the query rules.
+2. It writes a query and runs it with `safedep query exec`.
+3. If the server rejects the query, the error says why. The agent corrects the query and retries.
+
+Every query is scoped to your authenticated tenant. The agent reads data; it cannot change it. Each answer traces back to a real query, so you can ask the agent to show the SQL it ran.
+
+For the query language, the full table list, and the query rules, see [SafeDep Cloud SQL](/reference/sql-query).
+
+## Playbooks
+
+### Check exposure to a compromised package
+
+A package you use was compromised upstream. Find out if any endpoint installed it.
+
+```text
+The npm package eslint-config-prettier was compromised. Was it installed
+on any of our endpoints in the last 30 days? Which versions, and was it
+blocked or allowed?
+```
+
+The agent runs a query like:
+
+```sql
+SELECT endpoints.identifier, package_guard_events.package_version,
+       package_guard_events.package_action, package_guard_events.timestamp
+FROM package_guard_events
+JOIN endpoints ON endpoints.id = package_guard_events.invocation_id
+WHERE package_guard_events.package_name = 'eslint-config-prettier'
+  AND package_guard_events.timestamp >= '2026-07-11T00:00:00Z'
+ORDER BY package_guard_events.timestamp DESC
+```
+
+Each row is one decision on one endpoint. `PMG_PACKAGE_ACTION_BLOCKED` means PMG stopped the install. `PMG_PACKAGE_ACTION_CONFIRMED` means a person approved it after a warning. An allowed install of a compromised version is your incident to respond to.
+
+### Review what was blocked, and where
+
+```text
+What did PMG block across our endpoints this month? Group it by endpoint.
+```
+
+The agent filters `package_guard_events` on the blocked actions and joins to `endpoints`:
+
+```sql
+SELECT endpoints.identifier, package_guard_events.package_name,
+       package_guard_events.package_ecosystem, package_guard_events.timestamp
+FROM package_guard_events
+JOIN endpoints ON endpoints.id = package_guard_events.invocation_id
+WHERE package_guard_events.package_action = 'PMG_PACKAGE_ACTION_BLOCKED'
+ORDER BY package_guard_events.timestamp DESC
+```
+
+A block on one endpoint is often the first visible event of a campaign. Follow up with the exposure playbook above for the same package across the fleet.
+
+### Audit protection bypasses
+
+PMG records when a person bypasses protection. Review these regularly.
+
+```text
+Did anyone bypass PMG protection in the last two weeks? Show the endpoint,
+the package, and when it happened.
+```
+
+```sql
+SELECT endpoints.identifier, package_guard_events.package_name,
+       package_guard_events.timestamp
+FROM package_guard_events
+JOIN endpoints ON endpoints.id = package_guard_events.invocation_id
+WHERE package_guard_events.event_type = 'PMG_EVENT_TYPE_INSECURE_BYPASS'
+ORDER BY package_guard_events.timestamp DESC
+```
+
+The related `PMG_EVENT_TYPE_SANDBOX_OVERRIDE` event records sandbox policy overrides. Ask the agent to check both.
+
+### Find endpoints that stopped reporting
+
+An endpoint that stopped syncing is a blind spot: it still installs packages, and you no longer see them.
+
+```text
+Which endpoints have not synced in the last 30 days?
+```
+
+```sql
+SELECT endpoints.identifier, endpoints.endpoint_type, endpoints.last_sync_at
+FROM endpoints
+WHERE endpoints.last_sync_at < '2026-07-11T00:00:00Z'
+ORDER BY endpoints.last_sync_at ASC
+```
+
+The query language has no relative dates, so the agent computes the cutoff timestamp from today's date.
+
+### Get a current verdict on a suspect package
+
+Package Guard events record the decision PMG made at install time. Verdicts change: a package that passed last month may be known malware today. To judge a package during an investigation, get a fresh verdict with [on-demand package scanning](/package-security/scan/overview):
+
+```text
+An endpoint installed left-pad-utils 2.1.0 from npm last week. Scan it
+and tell me if it is safe.
+```
+
+The agent runs:
+
+```bash
+safedep package scan run "pkg:npm/left-pad-utils@2.1.0" -o json
+```
+
+The scan returns `malware`, `benign`, or `inconclusive`, with evidence. Treat `inconclusive` as needs-review. See [Scanning from CI and AI Agents](/package-security/scan/automation) for the scan contract.
+
+### See what AI tooling runs on an endpoint
+
+If your endpoints also run [Inventory](/governance/cloud/endpoint-hub/inventory) scans, the same loop answers questions about AI tooling:
+
+```text
+Which MCP servers were observed on our endpoints, and on which machines?
+```
+
+```sql
+SELECT inventory_events.item_identity, endpoints.identifier
+FROM inventory_events
+JOIN endpoints ON endpoints.id = inventory_events.app
+WHERE inventory_events.item_kind = 'INVENTORY_ITEM_KIND_MCP_SERVER'
+ORDER BY inventory_events.item_identity
+```
+
+Other item kinds cover coding agents, IDE extensions, and Agent Skills.
+
+## Ask narrow questions
+
+Results return one page at a time, up to 100 rows. Do not ask the agent to dump a table and search the output. Ask a narrow question, and let the agent filter server-side: a package name, a time range, one endpoint, one event type. When you need totals, ask for counts; the agent aggregates with `GROUP BY` instead of paging through rows.
+
+## Verify the answer
+
+Every agent answer maps to a query you can run yourself:
+
+1. Ask the agent to show the SQL it ran.
+2. Run it: `safedep query exec --sql "<statement>"`.
+3. Compare the result with the agent's summary.
+
+If the agent's answer looks wrong, the query is the first place to look. A missing time bound or a wrong enum value changes the result silently.
+
+<CardGroup cols={2}>
+  <Card title="SafeDep Cloud SQL" icon="database" href="/reference/sql-query">
+    The query language, full table list, and query rules.
+  </Card>
+  <Card title="Install the SafeDep Skill" icon="puzzle-piece" href="/get-started/safedep-skill">
+    Set up your AI coding agent for SafeDep.
+  </Card>
+  <Card title="Package Guard" icon="shield" href="/governance/cloud/endpoint-hub/package-guard">
+    Sync package events from your endpoints.
+  </Card>
+  <Card title="Talk to SafeDep" icon="comments" href="/governance/cloud/talk-to-safedep">
+    Ask your tenant questions in plain English.
+  </Card>
+</CardGroup>

--- a/governance/cloud/endpoint-hub/agentic-investigation.mdx
+++ b/governance/cloud/endpoint-hub/agentic-investigation.mdx
@@ -113,14 +113,21 @@ The query language has no relative dates, so the agent computes the cutoff times
 
 ### Get a current verdict on a suspect package
 
-Package Guard events record the decision PMG made at install time. Verdicts change: a package that passed last month may be known malware today. To judge a package during an investigation, get a fresh verdict with [on-demand package scanning](/package-security/scan/overview):
+Package Guard events record the decision PMG made at install time. Verdicts change: a package that passed last month may be known malware today. To judge a package during an investigation, get a current verdict. Two paths exist, and the agent should take the fast one first:
 
 ```text
-An endpoint installed left-pad-utils 2.1.0 from npm last week. Scan it
-and tell me if it is safe.
+An endpoint installed left-pad-utils 2.1.0 from npm last week. Is it safe?
+Check the known malicious packages database first. Run a full scan only if
+I ask for a deep dive.
 ```
 
-The agent runs:
+The fast path checks SafeDep's [known malicious packages database](/governance/cloud/malware-analysis). It is free and answers in milliseconds:
+
+```bash
+vet scan --purl pkg:npm/left-pad-utils@2.1.0 --malware-query
+```
+
+The slow path is an [on-demand package scan](/package-security/scan/overview): a full malware analysis of the exact version. It takes minutes and draws down your plan's scan allowance. Use it when the database has no verdict and the package deserves a deep dive:
 
 ```bash
 safedep package scan run "pkg:npm/left-pad-utils@2.1.0" -o json

--- a/governance/cloud/talk-to-safedep.mdx
+++ b/governance/cloud/talk-to-safedep.mdx
@@ -22,21 +22,7 @@ Install the SafeDep skill and your AI coding agent can answer questions about yo
 
 ## Install the skill
 
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    /plugin marketplace add safedep/skills
-    /plugin install safedep-agent-skills@safedep-agent-skills
-    ```
-    Turn on auto-update in Claude Code settings to stay on the current version.
-  </Tab>
-  <Tab title="Any agent">
-    ```bash
-    npx skills add safedep/skills
-    ```
-    Run `npx skills update` to refresh it later.
-  </Tab>
-</Tabs>
+Install the SafeDep skill in your agent. See [Install the SafeDep Skill](/get-started/safedep-skill) for Claude Code, Cursor, and other agents.
 
 ## Ask a question
 
@@ -65,3 +51,9 @@ The skill runs the same query interface you can drive by hand. To see the full t
 <Note>
 Queries are scoped to your authenticated tenant. The agent never sees data outside it, and you never write a tenant filter yourself.
 </Note>
+
+<CardGroup cols={1}>
+  <Card title="Agentic Endpoint Investigation" icon="magnifying-glass" href="/governance/cloud/endpoint-hub/agentic-investigation">
+    Investigation playbooks for developer endpoints: exposure checks, block reviews, bypass audits.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Two new pages and one deduplication:

- **`governance/cloud/endpoint-hub/agentic-investigation`** (new): a how-to guide for investigating developer endpoints with an AI coding agent, the `safedep` CLI, and SafeDep Cloud SQL. Six playbooks: exposure check for a compromised package, block review, bypass audit, endpoints that stopped reporting, package verdict (fast path via the known malicious packages database first, on-demand scan for deep dives), and AI tooling inventory. Each playbook gives the prompt, the query or command the agent runs, and how to read the result.
- **`get-started/safedep-skill`** (new): the canonical install page for the SafeDep Agent Skill (Claude Code plugin, `npx skills add`, Cursor), with the sign-in handoff for cloud queries.
- **`governance/cloud/talk-to-safedep`**: install steps replaced with a link to the new canonical page; cross-link card to the investigation guide added.
- `docs.json` navigation and `docs-ia.md` §7 page map updated (67 → 69 pages).

## Placement

Per `docs-ia.md`: the investigation guide is a how-to serving an endpoint-governance outcome, so it lives in Visibility & Governance › SafeDep Cloud › Endpoint Hub (sibling of Package Guard and MCP Advisor). The skill page routes entry points, so it lives in Get Started › Introduction next to `cli-tools`.

## Verification

- Every SQL statement, enum value, and join was checked against the Query v2 catalog (`control-tower/services/query/v2/catalog/catalog.go`) and the protos in `safedep/api`. Example outputs are not shown; queries have not been run against a live tenant. A validation pass on a real tenant before merge is recommended.
- CLI commands checked against `safedep/cli` and the shipped scan/malware-analysis docs pages.
- `mintlify broken-links` passes with only the three pre-existing `essentials/` failures.
- No em-dashes; one Diátaxis mode per page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPgsejyKH6FLEbhnBDNqdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPgsejyKH6FLEbhnBDNqdD)_